### PR TITLE
Allow hyperlink references with no surrounding backticks

### DIFF
--- a/src/Rst/RstParser.php
+++ b/src/Rst/RstParser.php
@@ -272,7 +272,7 @@ class RstParser
 
     public static function isLinkUsage(string $string): bool
     {
-        if (u($string)->match('/`([^`]+)`_/')) {
+        if (u($string)->match('/(?:`[^`]+`|\S+)_/')) {
             return true;
         }
 

--- a/src/Rst/Value/LinkUsage.php
+++ b/src/Rst/Value/LinkUsage.php
@@ -25,7 +25,8 @@ final class LinkUsage
 
     public static function fromLine(string $line): self
     {
-        preg_match('/`(.*)`_/', $line, $matches);
+        preg_match('/(`[^`]+`|\S+)_/', $line, $matches);
+        $matches[1] = trim($matches[1], '`');
 
         return new self(LinkName::fromString($matches[1]));
     }

--- a/src/Rule/UnusedLinks.php
+++ b/src/Rule/UnusedLinks.php
@@ -53,7 +53,7 @@ class UnusedLinks extends AbstractRule implements Rule, ResetInterface
                 $this->linkDefinitions[$definition->name()->value()] = $definition;
             }
 
-            preg_match_all('/`([^`]+)`_/', $lines->current(), $matches);
+            preg_match_all('/(?:`[^`]+`|\S+)_/', $lines->current(), $matches);
             if (!empty($matches[0])) {
                 foreach ($matches[0] as $match) {
                     if (RstParser::isLinkUsage($match)) {

--- a/tests/Rule/UnusedLinksTest.php
+++ b/tests/Rule/UnusedLinksTest.php
@@ -81,6 +81,18 @@ I am a `Link`_ and `Link2`_
 RST
             ),
         ];
+
+        yield [
+            null,
+            new RstSample(<<<RST
+I am `a Link`_, `some other Link`_ and Link2_
+
+.. _a Link: https://example.com
+.. _Link2: https://example2.com
+.. _`some other Link`: https://example3.com
+RST
+            ),
+        ];
     }
 
     public function invalidProvider(): \Generator


### PR DESCRIPTION
As you can see [in the reSt spec](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#hyperlink-references) it is not needed to surround hyperlink references with backticks:

> * Named hyperlink references:
>    * No start-string, end-string = "_".
>    * Start-string = "`", end-string = "`_". (Phrase references.)

In this case, only the first word before the underscore is used as reference (which is not the case with hyperlink targets btw, they allow space characters without surrounding backticks, as you can see in the test).

This currently breaks the linter in https://github.com/symfony/symfony-docs/pull/12861