### PR TITLE
Regression in UnusedLinks rule

### DIFF
--- a/src/Rst/RstParser.php
+++ b/src/Rst/RstParser.php
@@ -272,7 +272,7 @@ class RstParser
 
     public static function isLinkUsage(string $string): bool
     {
-        if (u($string)->match('/(?:`[^`]+`|\S+)_/')) {
+        if (u($string)->match('/(?:`[^`]+`|(?:(?!_)\w)+(?:[-._+:](?:(?!_)\w)+)*+)_/')) {
             return true;
         }
 

--- a/src/Rst/Value/LinkUsage.php
+++ b/src/Rst/Value/LinkUsage.php
@@ -25,7 +25,7 @@ final class LinkUsage
 
     public static function fromLine(string $line): self
     {
-        preg_match('/(`[^`]+`|\S+)_/', $line, $matches);
+        preg_match('/(`[^`]+`|(?:(?!_)\w)+(?:[-._+:](?:(?!_)\w)+)*+)_/', $line, $matches);
         $matches[1] = trim($matches[1], '`');
 
         return new self(LinkName::fromString($matches[1]));

--- a/src/Rule/UnusedLinks.php
+++ b/src/Rule/UnusedLinks.php
@@ -53,7 +53,7 @@ class UnusedLinks extends AbstractRule implements Rule, ResetInterface
                 $this->linkDefinitions[$definition->name()->value()] = $definition;
             }
 
-            preg_match_all('/(?:`[^`]+`|\S+)_/', $lines->current(), $matches);
+            preg_match_all('/(?:`[^`]+`|(?:(?!_)\w)+(?:[-._+:](?:(?!_)\w)+)*+)_/', $lines->current(), $matches);
             if (!empty($matches[0])) {
                 foreach ($matches[0] as $match) {
                     if (RstParser::isLinkUsage($match)) {

--- a/tests/Rule/UnusedLinksTest.php
+++ b/tests/Rule/UnusedLinksTest.php
@@ -93,6 +93,105 @@ I am `a Link`_, `some other Link`_ and Link2_
 RST
             ),
         ];
+
+        yield [
+            null,
+            new RstSample(<<<RST
+Date Handling
+~~~~~~~~~~~~~
+
+By default, the YAML parser will convert unquoted strings which look like a
+date or a date-time into a Unix timestamp; for example ``2016-05-27`` or
+``2016-05-27T02:59:43.1Z`` (`ISO-8601`_)::
+
+.. _`ISO-8601`: http://www.iso.org/iso/iso8601
+RST
+            ),
+        ];
+
+        yield [
+            null,
+            new RstSample(<<<RST
+Active Core Members
+~~~~~~~~~~~~~~~~~~~
+
+* **Project Leader**:
+
+  * **Fabien Potencier** (`fabpot`_).
+
+* **Mergers Team** (``@symfony/mergers`` on GitHub):
+
+  * **Nicolas Grekas** (`nicolas-grekas`_);
+  * **Christophe Coevoet** (`stof`_);
+  * **Christian Flothmann** (`xabbuh`_);
+  * **Tobias Schultze** (`Tobion`_);
+  * **Kévin Dunglas** (`dunglas`_);
+  * **Jakub Zalas** (`jakzal`_);
+  * **Javier Eguiluz** (`javiereguiluz`_);
+  * **Grégoire Pineau** (`lyrixx`_);
+  * **Ryan Weaver** (`weaverryan`_);
+  * **Robin Chalas** (`chalasr`_);
+  * **Maxime Steinhausser** (`ogizanagi`_);
+  * **Samuel Rozé** (`sroze`_);
+  * **Yonel Ceruto** (`yceruto`_).
+
+* **Security Team** (``@symfony/security`` on GitHub):
+
+  * **Fabien Potencier** (`fabpot`_);
+  * **Michael Cullum** (`michaelcullum`_).
+
+* **Recipes Team**:
+
+  * **Fabien Potencier** (`fabpot`_);
+  * **Tobias Nyholm** (`Nyholm`_).
+
+* **Documentation Team** (``@symfony/team-symfony-docs`` on GitHub):
+
+  * **Fabien Potencier** (`fabpot`_);
+  * **Ryan Weaver** (`weaverryan`_);
+  * **Christian Flothmann** (`xabbuh`_);
+  * **Wouter De Jong** (`wouterj`_);
+  * **Jules Pietri** (`HeahDude`_);
+  * **Javier Eguiluz** (`javiereguiluz`_).
+  * **Oskar Stark** (`OskarStark`_).
+
+Former Core Members
+~~~~~~~~~~~~~~~~~~~
+
+They are no longer part of the core team, but we are very grateful for all their
+Symfony contributions:
+
+* **Bernhard Schussek** (`webmozart`_);
+* **Abdellatif AitBoudad** (`aitboudad`_);
+* **Romain Neutron** (`romainneutron`_);
+* **Jordi Boggiano** (`Seldaek`_).
+
+.. _`fabpot`: https://github.com/fabpot/
+.. _`webmozart`: https://github.com/webmozart/
+.. _`Tobion`: https://github.com/Tobion/
+.. _`nicolas-grekas`: https://github.com/nicolas-grekas/
+.. _`stof`: https://github.com/stof/
+.. _`dunglas`: https://github.com/dunglas/
+.. _`jakzal`: https://github.com/jakzal/
+.. _`Seldaek`: https://github.com/Seldaek/
+.. _`weaverryan`: https://github.com/weaverryan/
+.. _`aitboudad`: https://github.com/aitboudad/
+.. _`xabbuh`: https://github.com/xabbuh/
+.. _`javiereguiluz`: https://github.com/javiereguiluz/
+.. _`lyrixx`: https://github.com/lyrixx/
+.. _`chalasr`: https://github.com/chalasr/
+.. _`ogizanagi`: https://github.com/ogizanagi/
+.. _`Nyholm`: https://github.com/Nyholm
+.. _`sroze`: https://github.com/sroze
+.. _`yceruto`: https://github.com/yceruto
+.. _`michaelcullum`: https://github.com/michaelcullum
+.. _`wouterj`: https://github.com/wouterj
+.. _`HeahDude`: https://github.com/HeahDude
+.. _`OskarStark`: https://github.com/OskarStark
+.. _`romainneutron`: https://github.com/romainneutron
+RST
+            ),
+        ];
     }
 
     public function invalidProvider(): \Generator


### PR DESCRIPTION
Probably after https://github.com/OskarStark/doctor-rst/pull/570 @wouterj 

I added 2 failing tests to this PR

All false positives in current `master` branch of the Symfony docs:
```
contributing/code/core_team.rst ✘
    1: The following link definitions aren't used anymore and should be removed: fabpot, webmozart, Tobion, nicolas-grekas, stof, dunglas, jakzal, Seldaek, weaverryan, aitboudad, xabbuh, javiereguiluz, lyrixx, chalasr, ogizanagi, Nyholm, sroze, yceruto, michaelcullum, wouterj, HeahDude, OskarStark, romainneutron

contributing/diversity/governance.rst ✘
    1: The following link definitions aren't used anymore and should be removed: lsmith77, michellesanver, nicolas-grekas, TimoBakx, zanbaldwin

components/cache/adapters/memcached_adapter.rst ✘
    1: The following link definitions aren't used anymore and should be removed: no-delay, keep-alive

components/yaml.rst ✘
    1: The following link definitions aren't used anymore and should be removed: ISO-8601

components/phpunit_bridge.rst ✘
    1: The following link definitions aren't used anymore and should be removed: @-silenced

create_framework/http_kernel_httpkernelinterface.rst ✘
    1: The following link definitions aren't used anymore and should be removed: ESI
```

cc @javiereguiluz