### PR TITLE
Exempt stack trace lines from prefix rule

### DIFF
--- a/src/Rule/PhpPrefixBeforeBinConsole.php
+++ b/src/Rule/PhpPrefixBeforeBinConsole.php
@@ -47,6 +47,11 @@ class PhpPrefixBeforeBinConsole extends AbstractRule implements Rule
             return null;
         }
 
+        if (preg_match('@/bin/console:\d+@u', $line->raw())
+            || preg_match('/php "%s\/\.\.\/bin\/console"/', $line->raw())) {
+            return null;
+        }
+
         if (RstParser::isLinkDefinition($line)) {
             return null;
         }

--- a/tests/Rule/PhpPrefixBeforeBinConsoleTest.php
+++ b/tests/Rule/PhpPrefixBeforeBinConsoleTest.php
@@ -39,6 +39,7 @@ class PhpPrefixBeforeBinConsoleTest extends TestCase
         yield [null, new RstSample('php "%s/../bin/console"')];
         yield [null, new RstSample('.. _`copying Symfony\'s bin/console source`: https://github.com/symfony/recipes/blob/master/symfony/console/3.3/bin/console')];
         yield [null, new RstSample('├─ bin/console')];
+        yield [null, new RstSample('Symfony\Component\Console\Application->run() at /home/greg/demo/bin/console:42')];
         yield ['Please add "php" prefix before "bin/console"', new RstSample('please execute bin/console foo')];
     }
 }


### PR DESCRIPTION
It makes not sense to have "at php /home/greg/demo/bin/console:42" in a
stack trace. Detection is based on the presence of the line number.

Relates to https://github.com/symfony/symfony-docs/pull/13699