### PR TITLE
Fix: Stricter checks

### DIFF
--- a/src/Rule/OnlyBackslashesInNamespaceInPhpCodeBlock.php
+++ b/src/Rule/OnlyBackslashesInNamespaceInPhpCodeBlock.php
@@ -42,7 +42,8 @@ class OnlyBackslashesInNamespaceInPhpCodeBlock extends AbstractRule implements R
         $lines->seek($number);
         $line = $lines->current();
 
-        if ($line->clean()->lower()->startsWith('namespace')
+        if ($line->clean()->lower()->startsWith('namespace ')
+            && $line->clean()->lower()->endsWith(';')
             && $line->clean()->containsAny('/')
             && $this->inPhpCodeBlock($lines, $number)
         ) {

--- a/src/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlock.php
+++ b/src/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlock.php
@@ -43,6 +43,7 @@ class OnlyBackslashesInUseStatementsInPhpCodeBlock extends AbstractRule implemen
         $line = $lines->current();
 
         if ($line->clean()->lower()->startsWith('use ')
+            && $line->clean()->lower()->endsWith(';')
             && $line->clean()->containsAny('/')
             && $this->inPhpCodeBlock($lines, $number)
         ) {


### PR DESCRIPTION
Before this was spotted as error:
```
security.rst ✘
  759: Please check "use the :doc:`remember me functionality </security/remember_me>`,", it should not contain "/"
   ->  use the :doc:`remember me functionality </security/remember_me>`,
```