### PR TITLE
Improve the output of UnusedLinks rule when there are many unused links

### DIFF
--- a/src/Rule/UnusedLinks.php
+++ b/src/Rule/UnusedLinks.php
@@ -71,8 +71,8 @@ class UnusedLinks extends AbstractRule implements Rule, ResetInterface
 
         if (!empty($this->linkDefinitions)) {
             return sprintf(
-                'The following link definitions aren\'t used anymore and should be removed: %s',
-                implode(', ', array_unique(array_keys($this->linkDefinitions)))
+                'The following link definitions aren\'t used anymore and should be removed: "%s"',
+                implode('", "', array_unique(array_keys($this->linkDefinitions)))
             );
         }
 

--- a/tests/Rule/UnusedLinksTest.php
+++ b/tests/Rule/UnusedLinksTest.php
@@ -197,7 +197,7 @@ RST
     public function invalidProvider(): \Generator
     {
         yield [
-            'The following link definitions aren\'t used anymore and should be removed: unused',
+            'The following link definitions aren\'t used anymore and should be removed: "unused"',
             new RstSample(<<<RST
 I am a `Link`_
 
@@ -208,12 +208,25 @@ RST
         ];
 
         yield [
-            'The following link definitions aren\'t used anymore and should be removed: unused',
+            'The following link definitions aren\'t used anymore and should be removed: "unused"',
             new RstSample(<<<RST
 I am a `Link`_
 
 .. _Link: https://example.com
 .. _unused: https://404.com
+RST
+            ),
+        ];
+
+        yield [
+            'The following link definitions aren\'t used anymore and should be removed: "unused2", "unused1", "unused 3"',
+            new RstSample(<<<RST
+I am a `Link`_
+
+.. _unused2: https://example.com/foo
+.. _Link: https://example.com
+.. _unused1: https://404.com
+.. _`unused 3`: https://example.org
 RST
             ),
         ];


### PR DESCRIPTION
First, thanks for creating and maintaining DOCtor-RST!

In a recent analysis I saw this:

![image](https://user-images.githubusercontent.com/73419/97777014-549ea380-1b6d-11eb-9409-2c415f78738c.png)

It's a bit confusing to me because there are many unused links but I don't know where each one starts and ends. That's why I propose this change ... but it's OK to close if you disagree. Cheers!