### PR TITLE
Add `max` as config option for line_length

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -323,6 +323,12 @@ Name | Required
 
 ## `line_length`
 
+#### Configuration options
+
+Name | Required | Default
+--- | --- | ---
+`max` | `false` | 80
+
 ## `lowercase_as_in_use_statements`
 
 #### Groups [`@Sonata`, `@Symfony`]

--- a/src/Rule/LineLength.php
+++ b/src/Rule/LineLength.php
@@ -14,14 +14,30 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class LineLength extends AbstractRule implements Rule
+class LineLength extends AbstractRule implements Rule, Configurable
 {
     private int $max;
 
-    public function __construct(int $max = 80)
+    public function configureOptions(OptionsResolver $resolver): OptionsResolver
     {
-        $this->max = $max;
+        $resolver
+            ->setDefault('max', 80)
+            ->setRequired('max')
+            ->setAllowedTypes('max', 'int')
+        ;
+
+        return $resolver;
+    }
+
+    public function setOptions(array $options): void
+    {
+        $resolver = $this->configureOptions(new OptionsResolver());
+
+        $resolvedOptions = $resolver->resolve($options);
+
+        $this->max = $resolvedOptions['max'];
     }
 
     public function check(Lines $lines, int $number): ?string

--- a/tests/Rule/LineLengthTest.php
+++ b/tests/Rule/LineLengthTest.php
@@ -26,10 +26,10 @@ class LineLengthTest extends TestCase
      */
     public function check(?string $expected, int $max, RstSample $sample)
     {
-        static::assertSame(
-            $expected,
-            (new LineLength($max))->check($sample->lines(), $sample->lineNumber())
-        );
+        $rule = (new LineLength());
+        $rule->setOptions(['max' => $max]);
+
+        static::assertSame($expected, $rule->check($sample->lines(), $sample->lineNumber()));
     }
 
     public function checkProvider()


### PR DESCRIPTION
Forgive me; I haven't had PHP in my hands for many, many years. Was heavily inspired by `MaxBlankLinesTest.php` 😅

With this PR I aim to add `max` as a configuration option for the `line_length` rule, very much like `max_blank_lines`, such that the YAML configuration can read:

```yaml
rules:
    line_length:
        max: 100
```

This was the simplest workaround for https://github.com/OskarStark/doctor-rst/issues/807 that I could find.