### PR TITLE
Enhancement: New rule BlankLineAfterColon

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -3,6 +3,7 @@
 * [american_english](#american_english)
 * [avoid_repetetive_words](#avoid_repetetive_words)
 * [be_kind_to_newcomers](#be_kind_to_newcomers) :exclamation:
+* [blank_line_after_colon](#blank_line_after_colon)
 * [blank_line_after_directive](#blank_line_after_directive)
 * [blank_line_after_filepath_in_code_block](#blank_line_after_filepath_in_code_block)
 * [blank_line_after_filepath_in_php_code_block](#blank_line_after_filepath_in_php_code_block)
@@ -143,6 +144,12 @@ Pattern | Message
 `/logically/i` | Please remove the word: %s
 `/merely/i` | Please remove the word: %s
 `/basic/i` | Please remove the word: %s
+
+## `blank_line_after_colon`
+
+  > _Make sure you have a blank line after a sentence which ends with a colon (`:`)._
+
+#### Groups [`@Sonata`, `@Symfony`]
 
 ## `blank_line_after_directive`
 

--- a/src/Rst/RstParser.php
+++ b/src/Rst/RstParser.php
@@ -233,4 +233,9 @@ class RstParser
     {
         return [] !== $line->clean()->match('/^(:[a-zA-Z]+:).*/');
     }
+
+    public static function isAnchor(Line $line): bool
+    {
+        return [] !== $line->raw()->match('/^\.\. _.*:$/');
+    }
 }

--- a/src/Rule/BlankLineAfterColon.php
+++ b/src/Rule/BlankLineAfterColon.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Rule;
+
+use App\Annotations\Rule\Description;
+use App\Rst\RstParser;
+use App\Traits\DirectiveTrait;
+use App\Value\Lines;
+use App\Value\RuleGroup;
+
+/**
+ * @Description("Make sure you have a blank line after a sentence which ends with a colon (`:`).")
+ */
+class BlankLineAfterColon extends AbstractRule implements LineContentRule
+{
+    use DirectiveTrait;
+
+    public static function getGroups(): array
+    {
+        return [
+            RuleGroup::Sonata(),
+            RuleGroup::Symfony(),
+        ];
+    }
+
+    public function check(Lines $lines, int $number): ?string
+    {
+        $lines->seek($number);
+        $line = $lines->current();
+
+        if ($line->isBlank() || !$line->clean()->endsWith(':')) {
+            return null;
+        }
+
+        if ($line->clean()->endsWith('::')
+            || RstParser::isOption($line)
+            || $this->in(RstParser::DIRECTIVE_CODE_BLOCK, clone $lines, $number, [RstParser::CODE_BLOCK_YAML])
+        ) {
+            return null;
+        }
+
+        $lines->next();
+
+        if (!$lines->valid()) {
+            return null;
+        }
+
+        if ($lines->current()->isBlank()) {
+            return null;
+        }
+
+        return sprintf(
+            'Please add a blank line after "%s"',
+            $line->clean()->toString()
+        );
+    }
+}

--- a/tests/Rst/RstParserTest.php
+++ b/tests/Rst/RstParserTest.php
@@ -260,8 +260,34 @@ final class RstParserTest extends TestCase
         yield [true, ' :lineos: '];
         yield [true, ':language: text'];
         yield [true, ' :language: text '];
+
         yield [false, ' '];
         yield [false, ''];
         yield [false, '.. class::'];
+        yield [false, '.. _env-var-processors:'];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider isAnchorProvider
+     */
+    public function isAnchor(bool $expected, string $string): void
+    {
+        static::assertSame($expected, RstParser::isAnchor(new Line($string)));
+    }
+
+    /**
+     * @return \Generator<array{0: bool, 1: string}>
+     */
+    public function isAnchorProvider(): \Generator
+    {
+        yield [true, '.. _env-var-processors:'];
+
+        yield [false, ' '];
+        yield [false, ''];
+        yield [false, '.. _`foo-bar`: https://google.com'];
+        yield [false, '.. _foo-bar: https://google.com'];
+        yield [false, '.. _foo: https://google.com'];
     }
 }

--- a/tests/Rule/BlankLineAfterColonTest.php
+++ b/tests/Rule/BlankLineAfterColonTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Rule;
+
+use App\Rule\BlankLineAfterColon;
+use App\Tests\RstSample;
+use PHPUnit\Framework\TestCase;
+
+final class BlankLineAfterColonTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider checkProvider
+     */
+    public function check(?string $expected, RstSample $sample): void
+    {
+        static::assertSame(
+            $expected,
+            (new BlankLineAfterColon())->check($sample->lines(), $sample->lineNumber())
+        );
+    }
+
+    /**
+     * @return \Generator<array{0: string|null, 1: RstSample}>
+     */
+    public function checkProvider(): \Generator
+    {
+        yield [
+            null,
+            new RstSample('temp'),
+        ];
+
+        yield [
+            null,
+            new RstSample('temp:'),
+        ];
+
+        yield [
+            null,
+            new RstSample([
+                'For example:',
+                '',
+                '    this is a text',
+            ]),
+        ];
+
+        yield [
+            'Please add a blank line after "For example:"',
+            new RstSample([
+                'For example:',
+                'For example::',
+            ]),
+        ];
+
+        yield [
+            null,
+            new RstSample([
+                '.. code-block:: yaml',
+                '',
+                '    session:',
+                '        foo:',
+            ], 2),
+        ];
+
+        yield [
+            null,
+            new RstSample([
+                '.. code-block:: yml',
+                '    :option:',
+                '    # config/services.yml',
+                '',
+                '    services:',
+            ], 1),
+        ];
+
+        yield [
+            null,
+            new RstSample([
+                '',
+                '.. _env-var-processors:',
+                '',
+                'Environment Variable Processors',
+                '===============================',
+                '',
+            ], 1),
+        ];
+    }
+}

--- a/tests/Traits/DirectiveTraitTest.php
+++ b/tests/Traits/DirectiveTraitTest.php
@@ -86,6 +86,20 @@ RST;
             [RstParser::CODE_BLOCK_JAVASCRIPT],
         ];
 
+        yield [
+            false,
+            new RstSample(<<<RST
+
+.. _env-var-processors:
+
+Environment Variable Processors
+===============================
+RST
+, 1),
+            RstParser::DIRECTIVE_CODE_BLOCK,
+            [RstParser::CODE_BLOCK_YAML],
+        ];
+
         $invalid = <<<'RST'
 Coding Standards
 ================


### PR DESCRIPTION
Fixes #839 

@smoench any idea why this test is failing?
```
1) App\Tests\Rule\BlankLineAfterColonTest::check with data set #6 (null, App\Tests\RstSample Object (...))
Failed asserting that 'Please add a blank line after ".. _env-var-processors:"' is identical to null.

/Users/oskar.stark/dev/privat/doctor-rst/tests/Rule/BlankLineAfterColonTest.php:33
```
