### PR TITLE
Adjust Argument variable must match type

### DIFF
--- a/src/Rule/ArgumentVariableMustMatchType.php
+++ b/src/Rule/ArgumentVariableMustMatchType.php
@@ -68,24 +68,33 @@ class ArgumentVariableMustMatchType extends AbstractRule implements LineContentR
         }
 
         $lines->next();
-        $lines->next();
 
         $messageParts = [];
-        foreach ($this->arguments as $argument) {
-            // This regex match argument type with bad argument name
-            $regex = sprintf(
-                '/%s \$(?!%s)(?<actualName>[a-z-A-Z\$]+)/',
-                $argument['type'],
-                $argument['name']
-            );
 
-            if ($match = $lines->current()->clean()->match($regex)) {
-                $messageParts[] = sprintf(
-                    'Please rename "$%s" to "$%s"',
-                    $match['actualName'],
+        while ($lines->valid()
+            && !$lines->current()->isDirective()
+        ) {
+            $line = $lines->current()->clean();
+
+            foreach ($this->arguments as $argument) {
+                // This regex match argument type with bad argument name
+                $regex = sprintf(
+                    '/%s \$(?!%s)(?<actualName>[a-z-A-Z\$]+)/',
+                    $argument['type'],
                     $argument['name']
                 );
+                $match = $line->match($regex);
+
+                if ($match) {
+                    $messageParts[] = sprintf(
+                        'Please rename "$%s" to "$%s"',
+                        $match['actualName'],
+                        $argument['name']
+                    );
+                }
             }
+
+            $lines->next();
         }
 
         return $messageParts ? implode('. ', $messageParts) : null;

--- a/tests/Rule/ArgumentVariableMustMatchTypeTest.php
+++ b/tests/Rule/ArgumentVariableMustMatchTypeTest.php
@@ -55,16 +55,17 @@ final class ArgumentVariableMustMatchTypeTest extends TestCase
     public function checkProvider(): \Generator
     {
         $codeBlocks = [
-            RstParser::CODE_BLOCK_PHP,
-            RstParser::CODE_BLOCK_PHP_ANNOTATIONS,
-            RstParser::CODE_BLOCK_PHP_ATTRIBUTES,
+            '.. code-block:: '.RstParser::CODE_BLOCK_PHP,
+            '.. code-block:: '.RstParser::CODE_BLOCK_PHP_ANNOTATIONS,
+            '.. code-block:: '.RstParser::CODE_BLOCK_PHP_ATTRIBUTES,
+            'A php code block follows::',
         ];
 
         foreach ($codeBlocks as $codeBlock) {
             yield [
                 'Please rename "$builder" to "$containerBuilder"',
                 new RstSample([
-                    '.. code-block:: '.$codeBlock,
+                    $codeBlock,
                     '',
                     'public function loadExtension(array $config, ContainerConfigurator $containerConfigurator, ContainerBuilder $builder): void',
                 ]),
@@ -73,7 +74,7 @@ final class ArgumentVariableMustMatchTypeTest extends TestCase
             yield [
                 'Please rename "$builder" to "$containerBuilder". Please rename "$configurator" to "$containerConfigurator"',
                 new RstSample([
-                    '.. code-block:: '.$codeBlock,
+                    $codeBlock,
                     '',
                     'public function loadExtension(array $config, ContainerConfigurator $configurator, ContainerBuilder $builder): void',
                 ]),
@@ -82,7 +83,7 @@ final class ArgumentVariableMustMatchTypeTest extends TestCase
             yield [
                 null,
                 new RstSample([
-                    '.. code-block:: '.$codeBlock,
+                    $codeBlock,
                     '',
                     'public function loadExtension(array $config, ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void',
                 ]),
@@ -91,7 +92,7 @@ final class ArgumentVariableMustMatchTypeTest extends TestCase
             yield [
                 'Please rename "$configurator" to "$containerConfigurator"',
                 new RstSample([
-                    '.. code-block:: '.$codeBlock,
+                    $codeBlock,
                     '',
                     'ContainerConfigurator $configurator',
                 ]),
@@ -100,9 +101,24 @@ final class ArgumentVariableMustMatchTypeTest extends TestCase
             yield [
                 null,
                 new RstSample([
-                    '.. code-block:: '.$codeBlock,
+                    $codeBlock,
                     '',
                     'ContainerConfigurator $containerConfigurator',
+                ]),
+            ];
+
+            yield [
+                'Please rename "$configurator" to "$containerConfigurator"',
+                new RstSample([
+                    $codeBlock,
+                    'some',
+                    'text',
+                    'before',
+                    'violation',
+                    'ContainerConfigurator $configurator',
+                    'some',
+                    'text',
+                    'after',
                 ]),
             ];
         }


### PR DESCRIPTION
I tried applied `argument_variable_must_match_type` to symfony-docs repo but had some issues

1) We assume argument matching is always after code block
```php
$lines->next();
$lines->next();
```
2) Php code block are whitelisted, but today violation is added on code block directive line.

```yaml
# do not report as violation
whitelist:
    lines:
        - '.. code-block:: php'
```

To fix first point, iterate on lines like `NoNamespaceAfterUseStatements` is enough.

Reporting violation on good line it's more complicated.
We must have a context in order to know if current line is in a php directive. We can achieve this by checking previous lines (maybe introducing `isInCodeBlockDirectiveOfType($lines, [RstParser::CODE_BLOCK_PHP, RstParser::CODE_BLOCK_PHP_ANNOTATIONS])`).
This solution is not ideal, because foreach line cheked, we will go back in order to determine directive.

Do you have a better solution or is this the way ?