### PR TITLE
NoExplicitUseOfCodeBlockPhp can have image has previous directive or terminal code block

### DIFF
--- a/src/Rule/NoExplicitUseOfCodeBlockPhp.php
+++ b/src/Rule/NoExplicitUseOfCodeBlockPhp.php
@@ -35,6 +35,7 @@ class NoExplicitUseOfCodeBlockPhp extends AbstractRule implements LineContentRul
         RstParser::DIRECTIVE_VERSIONADDED,
         RstParser::DIRECTIVE_VERSIONCHANGED,
         RstParser::DIRECTIVE_WARNING,
+        RstParser::DIRECTIVE_IMAGE,
     ];
 
     public static function getGroups(): array
@@ -81,8 +82,14 @@ class NoExplicitUseOfCodeBlockPhp extends AbstractRule implements LineContentRul
             }
         }
 
-        // check if the previous code block is php code block
-        if ($this->previousDirectiveIs(RstParser::DIRECTIVE_CODE_BLOCK, $lines, $number, [RstParser::CODE_BLOCK_PHP, RstParser::CODE_BLOCK_YAML])) {
+        $previousAllowedDirectiveTypes = [
+            RstParser::CODE_BLOCK_PHP,
+            RstParser::CODE_BLOCK_YAML,
+            RstParser::CODE_BLOCK_TERMINAL,
+        ];
+
+        // check if the previous code block is php, yaml or terminal code block
+        if ($this->previousDirectiveIs(RstParser::DIRECTIVE_CODE_BLOCK, $lines, $number, $previousAllowedDirectiveTypes)) {
             return null;
         }
 

--- a/tests/Rule/NoExplicitUseOfCodeBlockPhpTest.php
+++ b/tests/Rule/NoExplicitUseOfCodeBlockPhpTest.php
@@ -530,7 +530,7 @@ This is nice PHP code, isn't it?
 
     echo 'Hello World!';
 RST
-            , 2),
+                , 2),
         ];
 
         yield 'php code block following a configuration-block' => [
@@ -546,7 +546,22 @@ RST
 
     echo 'Hello World!';
 RST
-            , 6),
+                , 6),
+        ];
+
+        yield 'php code block following a terminal block' => [
+            null,
+            new RstSample(<<<'RST'
+.. code-block:: terminal
+
+    $ php bin/console make:user
+
+.. code-block:: php
+
+    echo 'Hello World!';
+    }
+RST
+                , 4),
         ];
 
         yield 'php code block unsing an option' => [


### PR DESCRIPTION
In order to remove this config from `.doctor-rst.yaml` in `symfony-docs`, we had to allow some cases.

```yaml
whitelist:
    lines:
        - '.. code-block:: php'
```

```txt
 Analyze *.rst(.inc) files in: /github/workspace
 Used config file:             /github/workspace/.doctor-rst.yaml

components/console/helpers/cursor.rst ✘
   19: Please do not use ".. code-block:: php", use "::" instead.
   ->  .. code-block:: php

security.rst ✘
  121: Please do not use ".. code-block:: php", use "::" instead.
   ->  .. code-block:: php
  676: Please do not use ".. code-block:: php", use "::" instead.
   ->  .. code-block:: php
 1038: Please do not use ".. code-block:: php", use "::" instead.
   ->  .. code-block:: php
```

This PR

- Allow image as previous directive
- Allow terminal as previous code block

(Hope it's last PR here for enabling ArgumentVariableMustMatchType)