### PR TITLE
No contraction missing cases

### DIFF
--- a/src/Rule/NoContraction.php
+++ b/src/Rule/NoContraction.php
@@ -39,7 +39,7 @@ class NoContraction extends CheckListRule implements LineContentRule
         $line = $lines->current();
 
         if (preg_match($this->search, $line->raw()->toString(), $matches)) {
-            return sprintf($this->message, $matches[0]);
+            return sprintf($this->message, $matches['contraction']);
         }
 
         return null;
@@ -55,14 +55,17 @@ class NoContraction extends CheckListRule implements LineContentRule
      */
     public static function getList(): array
     {
+        // We match contraction when it is start of string or char before is not an alnum
+        $baseRegex = '/(^|[^[:alnum:]])(?<contraction>%s)/i';
+
         return [
-            '/i\'m/i' => null,
-            '/(you|we|they)\'re/i' => null,
-            '/(he|she|it)\'s/i' => null,
-            '/(you|we|they)\'ve/i' => null,
-            '/(i|you|he|she|it|we|they)\'ll/i' => null,
-            '/(i|you|he|she|it|we|they)\'d/i' => null,
-            '/(aren|can|couldn|didn|hasn|haven|isn|mustn|shan|shouldn|wasn|weren|won|wouldn)\'t/i' => null,
+            sprintf($baseRegex, "i\'m") => null,
+            sprintf($baseRegex, "(you|we|they)\'re") => null,
+            sprintf($baseRegex, "(he|she|it)\'s") => null,
+            sprintf($baseRegex, "(you|we|they)\'ve") => null,
+            sprintf($baseRegex, "(i|you|he|she|it|we|they)\'ll") => null,
+            sprintf($baseRegex, "(i|you|he|she|it|we|they)\'d") => null,
+            sprintf($baseRegex, "(aren|can|couldn|didn|hasn|haven|isn|mustn|shan|shouldn|wasn|weren|won|wouldn)\'t") => null,
         ];
     }
 }

--- a/tests/Rule/NoContractionTest.php
+++ b/tests/Rule/NoContractionTest.php
@@ -105,6 +105,8 @@ final class NoContractionTest extends TestCase
             'were not',
             'will not',
             'would not',
+            // valid usages
+            "use PHPUnit's",
         ];
 
         foreach ($valids as $valid) {

--- a/tests/Rule/NoContractionTest.php
+++ b/tests/Rule/NoContractionTest.php
@@ -118,63 +118,70 @@ final class NoContractionTest extends TestCase
 
         $invalids = [
             // am
-            "i'm",
+            "i'm" => null,
             // are
-            "you're",
-            "we're",
-            "they're",
+            "you're" => null,
+            "we're" => null,
+            "they're" => null,
             // is and hase
-            "he's",
-            "she's",
-            "it's",
+            "he's" => null,
+            "she's" => null,
+            "it's" => null,
             // have
-            "you've",
-            "we've",
-            "they've",
+            "you've" => null,
+            "we've" => null,
+            "they've" => null,
             // will
-            "i'll",
-            "you'll",
-            "he'll",
-            "she'll",
-            "it'll",
-            "we'll",
-            "they'll",
+            "i'll" => null,
+            "you'll" => null,
+            "he'll" => null,
+            "she'll" => null,
+            "it'll" => null,
+            "we'll" => null,
+            "they'll" => null,
             // had and would
-            "i'd",
-            "you'd",
-            "he'd",
-            "she'd",
-            "it'd",
-            "we'd",
-            "they'd",
+            "i'd" => null,
+            "you'd" => null,
+            "he'd" => null,
+            "she'd" => null,
+            "it'd" => null,
+            "we'd" => null,
+            "they'd" => null,
             // not
-            "aren't",
-            "can't",
-            "couldn't",
-            "didn't",
-            "hasn't",
-            "haven't",
-            "isn't",
-            "mustn't",
-            "shan't",
-            "shouldn't",
-            "wasn't",
-            "weren't",
-            "won't",
-            "wouldn't",
+            "aren't" => null,
+            "can't" => null,
+            "couldn't" => null,
+            "didn't" => null,
+            "hasn't" => null,
+            "haven't" => null,
+            "isn't" => null,
+            "mustn't" => null,
+            "shan't" => null,
+            "shouldn't" => null,
+            "wasn't" => null,
+            "weren't" => null,
+            "won't" => null,
+            "wouldn't" => null,
+            // invalid usages
+            "foobar it's" => "it's",
+            "(it's" => "it's",
+            " it's" => "it's",
         ];
 
-        foreach ($invalids as $invalid) {
+        foreach ($invalids as $invalid => $matched) {
             yield $invalid => [
-                sprintf('Please do not use contraction for: %s', $invalid),
+                sprintf('Please do not use contraction for: %s', $matched ?? $invalid),
                 new RstSample($invalid),
             ];
 
             $invalidUppercase = ucfirst($invalid);
-            yield $invalidUppercase => [
-                sprintf('Please do not use contraction for: %s', $invalidUppercase),
-                new RstSample($invalidUppercase),
-            ];
+
+            if ($invalidUppercase !== $invalid) {
+                yield $invalidUppercase => [
+                    sprintf('Please do not use contraction for: %s', $matched ?? $invalidUppercase),
+                    new RstSample($invalidUppercase),
+                ];
+            }
         }
     }
 }


### PR DESCRIPTION
We must adjust matching regex for theses cases

```
 components/phpunit_bridge.rst ✘
   15: Please do not use contraction for: it's
   ->  locale-sensitive tests, use PHPUnit's ``setLocale()`` method);
  399: Please do not use contraction for: it's
   ->  the `PHPUnit's assertStringMatchesFormat()`_ method. If you expect more than one
 1062: Please do not use contraction for: it's
   ->  .. _`PHPUnit's assertStringMatchesFormat()`: https://phpunit.de/manual/current/en/appendixes.assertions.html#appendixes.assertions.assertStringMatchesFormat
```

However I don't know how to tell "Nothing before or char before must be an alnum" 

`'/[[:alnum:]](he|she|it)\'s/i'` not works when there is no char before but's is ok for other cases.

Do you have an idea @OskarStark ?