### PR TITLE
using Violation object instead of strings

### DIFF
--- a/src/Rule/AmericanEnglish.php
+++ b/src/Rule/AmericanEnglish.php
@@ -17,7 +17,10 @@ use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Ensure only American English is used.")
@@ -36,16 +39,21 @@ class AmericanEnglish extends CheckListRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if (preg_match($this->search, $line->raw()->toString(), $matches)) {
-            return sprintf($this->message, $matches[0]);
+            return Violation::from(
+                sprintf($this->message, $matches[0]),
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 
     public static function getDefaultMessage(): string

--- a/src/Rule/BeKindToNewcomers.php
+++ b/src/Rule/BeKindToNewcomers.php
@@ -15,7 +15,10 @@ namespace App\Rule;
 
 use App\Annotations\Rule\Description;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Do not use belittling words!")
@@ -27,16 +30,23 @@ class BeKindToNewcomers extends CheckListRule implements LineContentRule
         return [RuleGroup::Experimental()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if (preg_match($this->search, $line->raw()->toString(), $matches)) {
-            return sprintf($this->message, $matches[0]);
+            $message = sprintf($this->message, $matches[0]);
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 
     public static function getDefaultMessage(): string

--- a/src/Rule/BlankLineAfterFilepathInCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInCodeBlock.php
@@ -16,7 +16,10 @@ namespace App\Rule;
 use App\Annotations\Rule\Description;
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Make sure you have a blank line after a filepath in a code block. This rule respects PHP, YAML, XML and Twig.")
@@ -31,13 +34,13 @@ class BlankLineAfterFilepathInCodeBlock extends AbstractRule implements LineCont
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if (!RstParser::directiveIs($line, RstParser::DIRECTIVE_CODE_BLOCK)) {
-            return null;
+            return NullViolation::create();
         }
 
         $lines->next();
@@ -45,35 +48,42 @@ class BlankLineAfterFilepathInCodeBlock extends AbstractRule implements LineCont
 
         // PHP
         if ($matches = $lines->current()->clean()->match('/^\/\/(.*)\.php$/')) {
-            return $this->validateBlankLine($lines, $matches);
+            return $this->validateBlankLine($lines, $matches, $filename);
         }
 
         // YML / YAML
         if ($matches = $lines->current()->clean()->match('/^#(.*)\.(yml|yaml)$/')) {
-            return $this->validateBlankLine($lines, $matches);
+            return $this->validateBlankLine($lines, $matches, $filename);
         }
 
         // XML
         if ($matches = $lines->current()->clean()->match('/^<!--(.*)\.xml(.*)-->$/')) {
-            return $this->validateBlankLine($lines, $matches);
+            return $this->validateBlankLine($lines, $matches, $filename);
         }
 
         // TWIG
         if ($matches = $lines->current()->clean()->match('/^{#(.*)\.twig(.*)#}/')) {
-            return $this->validateBlankLine($lines, $matches);
+            return $this->validateBlankLine($lines, $matches, $filename);
         }
 
-        return null;
+        return NullViolation::create();
     }
 
-    private function validateBlankLine(Lines $lines, array $matches): ?string
+    private function validateBlankLine(Lines $lines, array $matches, string $filename): ViolationInterface
     {
         $lines->next();
 
         if (!$lines->current()->isBlank()) {
-            return sprintf('Please add a blank line after "%s"', trim($matches[0]));
+            $message = sprintf('Please add a blank line after "%s"', trim($matches[0]));
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/BlankLineAfterFilepathInPhpCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInPhpCodeBlock.php
@@ -17,13 +17,16 @@ use App\Annotations\Rule\Description;
 use App\Helper\PhpHelper;
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Make sure you have a blank line after a filepath in a PHP code block.")
  */
 class BlankLineAfterFilepathInPhpCodeBlock extends AbstractRule implements LineContentRule
 {
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
@@ -34,7 +37,7 @@ class BlankLineAfterFilepathInPhpCodeBlock extends AbstractRule implements LineC
             && !RstParser::codeBlockDirectiveIsTypeOf($line, RstParser::CODE_BLOCK_PHP_SYMFONY)
             && !RstParser::codeBlockDirectiveIsTypeOf($line, RstParser::CODE_BLOCK_PHP_STANDALONE)
         ) {
-            return null;
+            return NullViolation::create();
         }
 
         $lines->next();
@@ -42,20 +45,27 @@ class BlankLineAfterFilepathInPhpCodeBlock extends AbstractRule implements LineC
 
         // PHP
         if ($matches = $lines->current()->clean()->match('/^\/\/(.*)\.php$/')) {
-            return $this->validateBlankLine($lines, $matches);
+            return $this->validateBlankLine($lines, $matches, $filename);
         }
 
-        return null;
+        return NullViolation::create();
     }
 
-    private function validateBlankLine(Lines $lines, array $matches): ?string
+    private function validateBlankLine(Lines $lines, array $matches, string $filename): ViolationInterface
     {
         $lines->next();
 
         if (!$lines->current()->isBlank() && !PhpHelper::isComment($lines->current())) {
-            return sprintf('Please add a blank line after "%s"', trim($matches[0]));
+            $message = sprintf('Please add a blank line after "%s"', trim($matches[0]));
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/BlankLineAfterFilepathInXmlCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInXmlCodeBlock.php
@@ -17,19 +17,22 @@ use App\Annotations\Rule\Description;
 use App\Helper\XmlHelper;
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Make sure you have a blank line after a filepath in a XML code block.")
  */
 class BlankLineAfterFilepathInXmlCodeBlock extends AbstractRule implements LineContentRule
 {
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if (!RstParser::codeBlockDirectiveIsTypeOf($line, RstParser::CODE_BLOCK_XML)) {
-            return null;
+            return NullViolation::create();
         }
 
         $lines->next();
@@ -37,20 +40,27 @@ class BlankLineAfterFilepathInXmlCodeBlock extends AbstractRule implements LineC
 
         // XML
         if ($matches = $lines->current()->clean()->match('/^<!--(.*)\.(xml|xlf|xliff)(.*)-->$/')) {
-            return $this->validateBlankLine($lines, $matches);
+            return $this->validateBlankLine($lines, $matches, $filename);
         }
 
-        return null;
+        return NullViolation::create();
     }
 
-    private function validateBlankLine(Lines $lines, array $matches): ?string
+    private function validateBlankLine(Lines $lines, array $matches, string $filename): ViolationInterface
     {
         $lines->next();
 
         if (!$lines->current()->isBlank() && !XmlHelper::isComment($lines->current())) {
-            return sprintf('Please add a blank line after "%s"', trim($matches[0]));
+            $message = sprintf('Please add a blank line after "%s"', trim($matches[0]));
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/BlankLineAfterFilepathInYamlCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInYamlCodeBlock.php
@@ -17,13 +17,16 @@ use App\Annotations\Rule\Description;
 use App\Helper\YamlHelper;
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Make sure you have a blank line after a filepath in a YAML code block.")
  */
 class BlankLineAfterFilepathInYamlCodeBlock extends AbstractRule implements LineContentRule
 {
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
@@ -31,7 +34,7 @@ class BlankLineAfterFilepathInYamlCodeBlock extends AbstractRule implements Line
         if (!RstParser::codeBlockDirectiveIsTypeOf($line, RstParser::CODE_BLOCK_YAML)
             && !RstParser::codeBlockDirectiveIsTypeOf($line, RstParser::CODE_BLOCK_YML)
         ) {
-            return null;
+            return NullViolation::create();
         }
 
         $lines->next();
@@ -39,20 +42,27 @@ class BlankLineAfterFilepathInYamlCodeBlock extends AbstractRule implements Line
 
         // YML / YAML
         if ($matches = $lines->current()->clean()->match('/^#(.*)\.(yml|yaml)$/')) {
-            return $this->validateBlankLine($lines, $matches);
+            return $this->validateBlankLine($lines, $matches, $filename);
         }
 
-        return null;
+        return NullViolation::create();
     }
 
-    private function validateBlankLine(Lines $lines, array $matches): ?string
+    private function validateBlankLine(Lines $lines, array $matches, string $filename): ViolationInterface
     {
         $lines->next();
 
         if (!$lines->current()->isBlank() && !YamlHelper::isComment($lines->current())) {
-            return sprintf('Please add a blank line after "%s"', trim($matches[0]));
+            $message = sprintf('Please add a blank line after "%s"', trim($matches[0]));
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/ComposerDevOptionAtTheEnd.php
+++ b/src/Rule/ComposerDevOptionAtTheEnd.php
@@ -17,7 +17,10 @@ use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Make sure Composer `--dev` option for `require` command is used at the end.")
@@ -33,15 +36,20 @@ class ComposerDevOptionAtTheEnd extends AbstractRule implements LineContentRule
         return [RuleGroup::Sonata()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->clean()->match('/composer require \-\-dev(.*)$/')) {
-            return 'Please move "--dev" option to the end of the command';
+            return Violation::from(
+                'Please move "--dev" option to the end of the command',
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/ComposerDevOptionNotAtTheEnd.php
+++ b/src/Rule/ComposerDevOptionNotAtTheEnd.php
@@ -17,7 +17,10 @@ use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Make sure Composer `--dev` option for `require` command is not used at the end.")
@@ -33,15 +36,20 @@ class ComposerDevOptionNotAtTheEnd extends AbstractRule implements LineContentRu
         return [RuleGroup::Symfony()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->clean()->match('/composer require(.*)\-\-dev$/')) {
-            return 'Please move "--dev" option before the package';
+            return Violation::from(
+                'Please move "--dev" option before the package',
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/DeprecatedDirectiveMinVersion.php
+++ b/src/Rule/DeprecatedDirectiveMinVersion.php
@@ -15,7 +15,10 @@ namespace App\Rule;
 
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DeprecatedDirectiveMinVersion extends AbstractRule implements LineContentRule, Configurable
@@ -46,27 +49,34 @@ class DeprecatedDirectiveMinVersion extends AbstractRule implements LineContentR
         return [RuleGroup::Symfony()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if (!RstParser::directiveIs($line, RstParser::DIRECTIVE_DEPRECATED)) {
-            return null;
+            return NullViolation::create();
         }
 
         if ($matches = $line->clean()->match(sprintf('/^%s(.*)$/', RstParser::DIRECTIVE_DEPRECATED))) {
             $version = trim($matches[1]);
 
             if (-1 === version_compare($version, $this->minVersion)) {
-                return sprintf(
+                $message = sprintf(
                     'Please only provide "%s" if the version is greater/equal "%s"',
                     RstParser::DIRECTIVE_DEPRECATED,
                     $this->minVersion
                 );
+
+                return Violation::from(
+                    $message,
+                    $filename,
+                    1,
+                    ''
+                );
             }
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/EnsureExactlyOneSpaceBeforeDirectiveType.php
+++ b/src/Rule/EnsureExactlyOneSpaceBeforeDirectiveType.php
@@ -17,7 +17,10 @@ use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Ensure exactly one space before directive type.")
@@ -35,19 +38,26 @@ class EnsureExactlyOneSpaceBeforeDirectiveType extends AbstractRule implements L
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if (!$line->clean()->match('/\.\.\s*[a-z\-]+::/')) {
-            return null;
+            return NullViolation::create();
         }
 
         if (!$line->clean()->match('/\.\.\ [a-z\-]+::/')) {
-            return 'Please use only one whitespace between ".." and the directive type.';
+            $message = 'Please use only one whitespace between ".." and the directive type.';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink.php
+++ b/src/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink.php
@@ -18,7 +18,10 @@ use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Ensure exactly one space between link definition and link.")
@@ -37,19 +40,26 @@ class EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink extends AbstractRule imp
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if (!RstParser::isLinkDefinition($line)) {
-            return null;
+            return NullViolation::create();
         }
 
         if ($line->clean()->containsAny(':  ')) {
-            return 'Please use only one whitespace between the link definition and the link.';
+            $message = 'Please use only one whitespace between the link definition and the link.';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/EnsureLinkDefinitionContainsValidUrl.php
+++ b/src/Rule/EnsureLinkDefinitionContainsValidUrl.php
@@ -19,7 +19,10 @@ use App\Annotations\Rule\ValidExample;
 use App\Rst\RstParser;
 use App\Rst\Value\LinkDefinition;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Ensure link definition contains valid link.")
@@ -38,7 +41,7 @@ class EnsureLinkDefinitionContainsValidUrl extends AbstractRule implements LineC
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
@@ -46,7 +49,7 @@ class EnsureLinkDefinitionContainsValidUrl extends AbstractRule implements LineC
         if ($line->isBlank()
             || !RstParser::isLinkDefinition($line)
         ) {
-            return null;
+            return NullViolation::create();
         }
 
         $linkDefinition = LinkDefinition::fromLine($line->raw()->toString());
@@ -58,12 +61,19 @@ class EnsureLinkDefinitionContainsValidUrl extends AbstractRule implements LineC
             && \in_array($parsed['scheme'], ['http', 'https'])
             && isset($parsed['host'])
         ) {
-            return null;
+            return NullViolation::create();
         }
 
-        return sprintf(
+        $message = sprintf(
             'Invalid url in "%s"',
             $line->clean()->toString()
+        );
+
+        return Violation::from(
+            $message,
+            $filename,
+            1,
+            ''
         );
     }
 }

--- a/src/Rule/ExtendAbstractAdmin.php
+++ b/src/Rule/ExtendAbstractAdmin.php
@@ -15,7 +15,10 @@ namespace App\Rule;
 
 use App\Annotations\Rule\Description;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Ensure `AbstractAdmin` and the corresponding namespace `Sonata\AdminBundle\Admin\AbstractAdmin` is used.")
@@ -27,19 +30,33 @@ class ExtendAbstractAdmin extends AbstractRule implements LineContentRule
         return [RuleGroup::Sonata()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current()->clean();
 
         if ($line->match('/^class(.*)extends Admin$/')) {
-            return 'Please extend AbstractAdmin instead of Admin';
+            $message = 'Please extend AbstractAdmin instead of Admin';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
         if ($line->match('/^use Sonata\\\\AdminBundle\\\\Admin\\\\Admin;/')) {
-            return 'Please use "Sonata\AdminBundle\Admin\AbstractAdmin" instead of "Sonata\AdminBundle\Admin\Admin"';
+            $message = 'Please use "Sonata\AdminBundle\Admin\AbstractAdmin" instead of "Sonata\AdminBundle\Admin\Admin"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/ExtendAbstractController.php
+++ b/src/Rule/ExtendAbstractController.php
@@ -15,7 +15,10 @@ namespace App\Rule;
 
 use App\Annotations\Rule\Description;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Ensure `AbstractController` and the corresponding namespace `Symfony\Bundle\FrameworkBundle\Controller\AbstractController` is used. Instead of `Symfony\Bundle\FrameworkBundle\Controller\Controller`.")
@@ -27,19 +30,33 @@ class ExtendAbstractController extends AbstractRule implements LineContentRule
         return [RuleGroup::Symfony()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current()->clean();
 
         if ($line->match('/^class(.*)extends Controller$/')) {
-            return 'Please extend AbstractController instead of Controller';
+            $message = 'Please extend AbstractController instead of Controller';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
         if ($line->match('/^use Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\Controller;/')) {
-            return 'Please use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead of "Symfony\Bundle\FrameworkBundle\Controller\Controller"';
+            $message = 'Please use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead of "Symfony\Bundle\FrameworkBundle\Controller\Controller"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/ExtendController.php
+++ b/src/Rule/ExtendController.php
@@ -15,7 +15,10 @@ namespace App\Rule;
 
 use App\Annotations\Rule\Description;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Ensure `Controller` and the corresponding namespace `Symfony\Bundle\FrameworkBundle\Controller\Controller` is used. Instead of `Symfony\Bundle\FrameworkBundle\Controller\AbstractController`.")
@@ -27,19 +30,33 @@ class ExtendController extends AbstractRule implements LineContentRule
         return [RuleGroup::Symfony()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current()->clean();
 
         if ($line->match('/^class(.*)extends AbstractController$/')) {
-            return 'Please extend Controller instead of AbstractController';
+            $message = 'Please extend Controller instead of AbstractController';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
         if ($line->match('/^use Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\AbstractController;/')) {
-            return 'Please use "Symfony\Bundle\FrameworkBundle\Controller\Controller" instead of "Symfony\Bundle\FrameworkBundle\Controller\AbstractController"';
+            $message = 'Please use "Symfony\Bundle\FrameworkBundle\Controller\Controller" instead of "Symfony\Bundle\FrameworkBundle\Controller\AbstractController"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/ExtensionXlfInsteadOfXliff.php
+++ b/src/Rule/ExtensionXlfInsteadOfXliff.php
@@ -17,7 +17,10 @@ use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Make sure to only use `.xlf` instead of `.xliff`.")
@@ -36,14 +39,21 @@ class ExtensionXlfInsteadOfXliff extends AbstractRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
 
         if ($matches = $lines->current()->raw()->match('/\.xliff/i')) {
-            return sprintf('Please use ".xlf" extension instead of "%s"', $matches[0]);
+            $message = sprintf('Please use ".xlf" extension instead of "%s"', $matches[0]);
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/FileContentRule.php
+++ b/src/Rule/FileContentRule.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\ViolationInterface;
 
 /**
  * Rules using this interface are only run once per file, and are
@@ -22,5 +23,5 @@ use App\Value\Lines;
  */
 interface FileContentRule extends Rule
 {
-    public function check(Lines $lines): ?string;
+    public function check(Lines $lines, string $filename): ViolationInterface;
 }

--- a/src/Rule/FileInfoRule.php
+++ b/src/Rule/FileInfoRule.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace App\Rule;
 
+use App\Value\ViolationInterface;
+
 /**
  * Rules using this interface are only run once,
  * and get a \SplFileInfo containing infos of the file.
  */
 interface FileInfoRule extends Rule
 {
-    public function check(\SplFileInfo $file): ?string;
+    public function check(\SplFileInfo $file): ViolationInterface;
 }

--- a/src/Rule/FilenameUsesDashesOnly.php
+++ b/src/Rule/FilenameUsesDashesOnly.php
@@ -16,7 +16,10 @@ namespace App\Rule;
 use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 use function Symfony\Component\String\u;
 
@@ -37,7 +40,7 @@ final class FilenameUsesDashesOnly extends AbstractRule implements FileInfoRule
         ];
     }
 
-    public function check(\SplFileInfo $fileInfo): ?string
+    public function check(\SplFileInfo $fileInfo): ViolationInterface
     {
         $filename = u($fileInfo->getFilename());
 
@@ -50,12 +53,19 @@ final class FilenameUsesDashesOnly extends AbstractRule implements FileInfoRule
         }
 
         if ($filename->containsAny('_')) {
-            return sprintf(
+            $message = sprintf(
                 'Please use dashes (-) for the filename: %s',
                 $fileInfo->getFilename()
             );
+
+            return Violation::from(
+                $message,
+                $fileInfo->getFilename(),
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/FilenameUsesUnderscoresOnly.php
+++ b/src/Rule/FilenameUsesUnderscoresOnly.php
@@ -16,7 +16,10 @@ namespace App\Rule;
 use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 use function Symfony\Component\String\u;
 
@@ -38,17 +41,24 @@ final class FilenameUsesUnderscoresOnly extends AbstractRule implements FileInfo
         ];
     }
 
-    public function check(\SplFileInfo $fileInfo): ?string
+    public function check(\SplFileInfo $fileInfo): ViolationInterface
     {
         $filename = u($fileInfo->getFilename());
 
         if ($filename->containsAny('-')) {
-            return sprintf(
+            $message = sprintf(
                 'Please use underscores (_) for the filename: %s',
                 $fileInfo->getFilename()
             );
+
+            return Violation::from(
+                $message,
+                $fileInfo->getFilename(),
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/FinalAdminClasses.php
+++ b/src/Rule/FinalAdminClasses.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class FinalAdminClasses extends AbstractRule implements LineContentRule
 {
@@ -23,15 +26,22 @@ class FinalAdminClasses extends AbstractRule implements LineContentRule
         return [RuleGroup::Sonata()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->clean()->match('/^class(.*)extends AbstractAdmin$/')) {
-            return 'Please use "final" for Admin class';
+            $message = 'Please use "final" for Admin class';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/FinalAdminExtensionClasses.php
+++ b/src/Rule/FinalAdminExtensionClasses.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class FinalAdminExtensionClasses extends AbstractRule implements LineContentRule
 {
@@ -23,15 +26,22 @@ class FinalAdminExtensionClasses extends AbstractRule implements LineContentRule
         return [RuleGroup::Sonata()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->clean()->match('/^class(.*)extends AbstractAdminExtension$/')) {
-            return 'Please use "final" for AdminExtension class';
+            $message = 'Please use "final" for AdminExtension class';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/KernelInsteadOfAppKernel.php
+++ b/src/Rule/KernelInsteadOfAppKernel.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class KernelInsteadOfAppKernel extends AbstractRule implements LineContentRule
 {
@@ -23,19 +26,33 @@ class KernelInsteadOfAppKernel extends AbstractRule implements LineContentRule
         return [RuleGroup::Sonata()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current()->raw();
 
         if ($line->match('/app\/AppKernel\.php/')) {
-            return 'Please use "src/Kernel.php" instead of "app/AppKernel.php"';
+            $message = 'Please use "src/Kernel.php" instead of "app/AppKernel.php"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
         if ($line->match('/AppKernel/')) {
-            return 'Please use "Kernel" instead of "AppKernel"';
+            $message = 'Please use "Kernel" instead of "AppKernel"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/LineContentRule.php
+++ b/src/Rule/LineContentRule.php
@@ -14,11 +14,12 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\ViolationInterface;
 
 /**
  * Rules using this interface run for every line of the file content.
  */
 interface LineContentRule extends Rule
 {
-    public function check(Lines $lines, int $number): ?string;
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface;
 }

--- a/src/Rule/LineLength.php
+++ b/src/Rule/LineLength.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class LineLength extends AbstractRule implements LineContentRule, Configurable
@@ -40,7 +43,7 @@ class LineLength extends AbstractRule implements LineContentRule, Configurable
         $this->max = $resolvedOptions['max'];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
@@ -48,9 +51,16 @@ class LineLength extends AbstractRule implements LineContentRule, Configurable
         $count = mb_strlen($line->clean()->toString());
 
         if ($count > $this->max) {
-            return sprintf('Line is to long (max %s) currently: %s', $this->max, $count);
+            $message = sprintf('Line is to long (max %s) currently: %s', $this->max, $count);
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/MaxBlankLines.php
+++ b/src/Rule/MaxBlankLines.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class MaxBlankLines extends AbstractRule implements LineContentRule, Configurable
@@ -54,12 +57,12 @@ class MaxBlankLines extends AbstractRule implements LineContentRule, Configurabl
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
 
         if (!$lines->current()->isBlank()) {
-            return null;
+            return NullViolation::create();
         }
 
         $blanklines = 1;
@@ -73,9 +76,16 @@ class MaxBlankLines extends AbstractRule implements LineContentRule, Configurabl
         }
 
         if ($blanklines > $this->max) {
-            return sprintf('Please use max %s blank lines, you used %s', $this->max, $blanklines);
+            $message = sprintf('Please use max %s blank lines, you used %s', $this->max, $blanklines);
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/MaxColons.php
+++ b/src/Rule/MaxColons.php
@@ -18,7 +18,10 @@ use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Traits\DirectiveTrait;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Make sure you have max 2 colons (`::`).")
@@ -39,15 +42,22 @@ final class MaxColons extends AbstractRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->isBlank() || !$line->clean()->endsWith(':::')) {
-            return null;
+            return NullViolation::create();
         }
 
-        return 'Please use max 2 colons at the end.';
+        $message = 'Please use max 2 colons at the end.';
+
+        return Violation::from(
+            $message,
+            $filename,
+            1,
+            ''
+        );
     }
 }

--- a/src/Rule/NoAdminYaml.php
+++ b/src/Rule/NoAdminYaml.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class NoAdminYaml extends AbstractRule implements LineContentRule
 {
@@ -23,23 +26,37 @@ class NoAdminYaml extends AbstractRule implements LineContentRule
         return [RuleGroup::Sonata()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current()->raw();
 
         if ($line->match('/_admin\.yaml/')) {
-            return null;
+            return NullViolation::create();
         }
 
         if ($line->match('/admin\.yml/')) {
-            return 'Please use "services.yaml" instead of "admin.yml"';
+            $message = 'Please use "services.yaml" instead of "admin.yml"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
         if ($line->match('/admin\.yaml/')) {
-            return 'Please use "services.yaml" instead of "admin.yaml"';
+            $message = 'Please use "services.yaml" instead of "admin.yaml"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoAppBundle.php
+++ b/src/Rule/NoAppBundle.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class NoAppBundle extends AbstractRule implements LineContentRule
 {
@@ -23,14 +26,21 @@ class NoAppBundle extends AbstractRule implements LineContentRule
         return [RuleGroup::Sonata()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
 
         if ($lines->current()->raw()->match('/AppBundle/')) {
-            return 'Please don\'t use "AppBundle" anymore';
+            $message = 'Please don\'t use "AppBundle" anymore';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoAppConsole.php
+++ b/src/Rule/NoAppConsole.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class NoAppConsole extends AbstractRule implements LineContentRule
 {
@@ -26,15 +29,22 @@ class NoAppConsole extends AbstractRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->raw()->match('/app\/console/')) {
-            return 'Please use "bin/console" instead of "app/console"';
+            $message = 'Please use "bin/console" instead of "app/console"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoBlankLineAfterFilepathInCodeBlock.php
+++ b/src/Rule/NoBlankLineAfterFilepathInCodeBlock.php
@@ -15,16 +15,19 @@ namespace App\Rule;
 
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class NoBlankLineAfterFilepathInCodeBlock extends AbstractRule implements LineContentRule
 {
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if (!RstParser::directiveIs($line, RstParser::DIRECTIVE_CODE_BLOCK)) {
-            return null;
+            return NullViolation::create();
         }
 
         $lines->next();
@@ -32,35 +35,42 @@ class NoBlankLineAfterFilepathInCodeBlock extends AbstractRule implements LineCo
 
         // PHP
         if (preg_match('/^\/\/(.*)\.php$/', $lines->current()->clean()->toString(), $matches)) {
-            return $this->validateBlankLine($lines, $matches);
+            return $this->validateBlankLine($lines, $matches, $filename);
         }
 
         // YML / YAML
         if (preg_match('/^#(.*)\.(yml|yaml)$/', $lines->current()->clean()->toString(), $matches)) {
-            return $this->validateBlankLine($lines, $matches);
+            return $this->validateBlankLine($lines, $matches, $filename);
         }
 
         // XML
         if (preg_match('/^<!--(.*)\.xml(.*)-->$/', $lines->current()->clean()->toString(), $matches)) {
-            return $this->validateBlankLine($lines, $matches);
+            return $this->validateBlankLine($lines, $matches, $filename);
         }
 
         // TWIG
         if (preg_match('/^{#(.*)\.twig(.*)#}/', $lines->current()->clean()->toString(), $matches)) {
-            return $this->validateBlankLine($lines, $matches);
+            return $this->validateBlankLine($lines, $matches, $filename);
         }
 
-        return null;
+        return NullViolation::create();
     }
 
-    private function validateBlankLine(Lines $lines, array $matches): ?string
+    private function validateBlankLine(Lines $lines, array $matches, string $filename): ViolationInterface
     {
         $lines->next();
 
         if ($lines->current()->isBlank()) {
-            return sprintf('Please remove blank line after "%s"', trim($matches[0]));
+            $message = sprintf('Please remove blank line after "%s"', trim($matches[0]));
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoBracketsInMethodDirective.php
+++ b/src/Rule/NoBracketsInMethodDirective.php
@@ -17,7 +17,10 @@ use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Ensure a :method: directive has special format.")
@@ -36,14 +39,21 @@ class NoBracketsInMethodDirective extends AbstractRule implements LineContentRul
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
 
         if ($lines->current()->raw()->match('/:method:`.*::.*\(\)`/')) {
-            return 'Please remove "()" inside :method: directive';
+            $message = 'Please remove "()" inside :method: directive';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoComposerPhar.php
+++ b/src/Rule/NoComposerPhar.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class NoComposerPhar extends AbstractRule implements LineContentRule
 {
@@ -23,14 +26,21 @@ class NoComposerPhar extends AbstractRule implements LineContentRule
         return [RuleGroup::Sonata()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
 
         if ($lines->current()->raw()->match('/composer\.phar/')) {
-            return 'Please use "composer" instead of "composer.phar"';
+            $message = 'Please use "composer" instead of "composer.phar"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoComposerReq.php
+++ b/src/Rule/NoComposerReq.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class NoComposerReq extends AbstractRule implements LineContentRule
 {
@@ -23,15 +26,22 @@ class NoComposerReq extends AbstractRule implements LineContentRule
         return [RuleGroup::Symfony()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->clean()->match('/composer req /')) {
-            return 'Please "composer require" instead of "composer req"';
+            $message = 'Please "composer require" instead of "composer req"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoConfigYaml.php
+++ b/src/Rule/NoConfigYaml.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class NoConfigYaml extends AbstractRule implements LineContentRule
 {
@@ -26,14 +29,21 @@ class NoConfigYaml extends AbstractRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
 
         if ($lines->current()->raw()->match('/app\/config\/config\.yml/')) {
-            return 'Please use specific config class in "config/packages/..." instead of "app/config/config.yml"';
+            $message = 'Please use specific config class in "config/packages/..." instead of "app/config/config.yml"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoContraction.php
+++ b/src/Rule/NoContraction.php
@@ -17,7 +17,10 @@ use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Ensure contractions are not used.")
@@ -35,16 +38,23 @@ class NoContraction extends CheckListRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if (preg_match($this->search, $line->raw()->toString(), $matches)) {
-            return sprintf($this->message, $matches['contraction']);
+            $message = sprintf($this->message, $matches['contraction']);
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 
     public static function getDefaultMessage(): string

--- a/src/Rule/NoInheritdocInCodeExamples.php
+++ b/src/Rule/NoInheritdocInCodeExamples.php
@@ -15,7 +15,10 @@ namespace App\Rule;
 
 use App\Traits\DirectiveTrait;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class NoInheritdocInCodeExamples extends AbstractRule implements LineContentRule
 {
@@ -29,7 +32,7 @@ class NoInheritdocInCodeExamples extends AbstractRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
@@ -37,9 +40,16 @@ class NoInheritdocInCodeExamples extends AbstractRule implements LineContentRule
         if ($line->raw()->match('/@inheritdoc/')
             && $this->inPhpCodeBlock($lines, $number)
         ) {
-            return 'Please do not use "@inheritdoc"';
+            $message = 'Please do not use "@inheritdoc"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoNamespaceAfterUseStatements.php
+++ b/src/Rule/NoNamespaceAfterUseStatements.php
@@ -15,7 +15,10 @@ namespace App\Rule;
 
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class NoNamespaceAfterUseStatements extends AbstractRule implements LineContentRule
 {
@@ -27,7 +30,7 @@ class NoNamespaceAfterUseStatements extends AbstractRule implements LineContentR
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
@@ -38,7 +41,7 @@ class NoNamespaceAfterUseStatements extends AbstractRule implements LineContentR
             && !RstParser::codeBlockDirectiveIsTypeOf($line, RstParser::CODE_BLOCK_PHP_SYMFONY)
             && !RstParser::codeBlockDirectiveIsTypeOf($line, RstParser::CODE_BLOCK_PHP_STANDALONE)
         ) {
-            return null;
+            return NullViolation::create();
         }
 
         $indention = $line->indention();
@@ -59,7 +62,14 @@ class NoNamespaceAfterUseStatements extends AbstractRule implements LineContentR
 
             if ($line->match('/^namespace (.*);$/')) {
                 if ($useStatementFound) {
-                    return 'Please move the namespace before the use statement(s)';
+                    $message = 'Please move the namespace before the use statement(s)';
+
+                    return Violation::from(
+                        $message,
+                        $filename,
+                        1,
+                        ''
+                    );
                 }
                 break;
             }
@@ -67,6 +77,6 @@ class NoNamespaceAfterUseStatements extends AbstractRule implements LineContentR
             $lines->next();
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoPhpOpenTagInCodeBlockPhpDirective.php
+++ b/src/Rule/NoPhpOpenTagInCodeBlockPhpDirective.php
@@ -15,7 +15,10 @@ namespace App\Rule;
 
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class NoPhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineContentRule
 {
@@ -27,7 +30,7 @@ class NoPhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineCo
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
@@ -38,7 +41,7 @@ class NoPhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineCo
             && !RstParser::codeBlockDirectiveIsTypeOf($line, RstParser::CODE_BLOCK_PHP_SYMFONY, true)
             && !RstParser::codeBlockDirectiveIsTypeOf($line, RstParser::CODE_BLOCK_PHP_STANDALONE, true)
         ) {
-            return null;
+            return NullViolation::create();
         }
 
         $lines->next();
@@ -48,9 +51,16 @@ class NoPhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineCo
         $nextLine = $lines->current();
 
         if ('<?php' === $nextLine->clean()->toString()) {
-            return sprintf('Please remove PHP open tag after "%s" directive', $line->raw()->toString());
+            $message = sprintf('Please remove PHP open tag after "%s" directive', $line->raw()->toString());
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoPhpPrefixBeforeBinConsole.php
+++ b/src/Rule/NoPhpPrefixBeforeBinConsole.php
@@ -17,7 +17,10 @@ use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Ensure `bin/console` is not prefixed with `php`.")
@@ -33,15 +36,22 @@ class NoPhpPrefixBeforeBinConsole extends AbstractRule implements LineContentRul
         return [RuleGroup::Sonata()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->raw()->match('/php bin\/console/')) {
-            return 'Please remove "php" prefix before "bin/console"';
+            $message = 'Please remove "php" prefix before "bin/console"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoPhpPrefixBeforeComposer.php
+++ b/src/Rule/NoPhpPrefixBeforeComposer.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class NoPhpPrefixBeforeComposer extends AbstractRule implements LineContentRule
 {
@@ -23,15 +26,22 @@ class NoPhpPrefixBeforeComposer extends AbstractRule implements LineContentRule
         return [RuleGroup::Sonata()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->raw()->match('/php composer/')) {
-            return 'Please remove "php" prefix';
+            $message = 'Please remove "php" prefix';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/NoSpaceBeforeSelfXmlClosingTag.php
+++ b/src/Rule/NoSpaceBeforeSelfXmlClosingTag.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class NoSpaceBeforeSelfXmlClosingTag extends AbstractRule implements LineContentRule
 {
@@ -23,15 +26,22 @@ class NoSpaceBeforeSelfXmlClosingTag extends AbstractRule implements LineContent
         return [RuleGroup::Sonata()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ('/>' !== $line->clean()->toString() && $line->raw()->match('/\ \/>/')) {
-            return 'Please remove space before "/>"';
+            $message = 'Please remove space before "/>"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/OnlyBackslashesInNamespaceInPhpCodeBlock.php
+++ b/src/Rule/OnlyBackslashesInNamespaceInPhpCodeBlock.php
@@ -18,7 +18,10 @@ use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Traits\DirectiveTrait;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("A namespace declaration in a PHP code-block should only contain backslashes.")
@@ -39,7 +42,7 @@ class OnlyBackslashesInNamespaceInPhpCodeBlock extends AbstractRule implements L
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
@@ -49,12 +52,19 @@ class OnlyBackslashesInNamespaceInPhpCodeBlock extends AbstractRule implements L
             && $line->clean()->containsAny('/')
             && $this->inPhpCodeBlock($lines, $number)
         ) {
-            return sprintf(
+            $message = sprintf(
                 'Please check "%s", it should not contain "/"',
                 $line->clean()->toString()
             );
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlock.php
+++ b/src/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlock.php
@@ -18,7 +18,10 @@ use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Traits\DirectiveTrait;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("A use statement in a PHP code-block should only contain backslashes.")
@@ -39,7 +42,7 @@ class OnlyBackslashesInUseStatementsInPhpCodeBlock extends AbstractRule implemen
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
@@ -49,12 +52,19 @@ class OnlyBackslashesInUseStatementsInPhpCodeBlock extends AbstractRule implemen
             && $line->clean()->containsAny('/')
             && $this->inPhpCodeBlock($lines, $number)
         ) {
-            return sprintf(
+            $message = sprintf(
                 'Please check "%s", it should not contain "/"',
                 $line->clean()->toString()
             );
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/PhpOpenTagInCodeBlockPhpDirective.php
+++ b/src/Rule/PhpOpenTagInCodeBlockPhpDirective.php
@@ -15,10 +15,13 @@ namespace App\Rule;
 
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class PhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineContentRule
 {
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
@@ -29,7 +32,7 @@ class PhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineCont
             && !RstParser::codeBlockDirectiveIsTypeOf($line, RstParser::CODE_BLOCK_PHP_SYMFONY, true)
             && !RstParser::codeBlockDirectiveIsTypeOf($line, RstParser::CODE_BLOCK_PHP_STANDALONE, true)
         ) {
-            return null;
+            return NullViolation::create();
         }
 
         $lines->next();
@@ -39,9 +42,16 @@ class PhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineCont
         $nextLine = $lines->current();
 
         if (!$nextLine->clean()->startsWith('<?php')) {
-            return sprintf('Please add PHP open tag after "%s" directive', $line->raw()->toString());
+            $message = sprintf('Please add PHP open tag after "%s" directive', $line->raw()->toString());
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/ReplaceCodeBlockTypes.php
+++ b/src/Rule/ReplaceCodeBlockTypes.php
@@ -16,7 +16,10 @@ namespace App\Rule;
 use App\Annotations\Rule\Description;
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Propose alternatives for disallowed code block types.")
@@ -31,16 +34,23 @@ class ReplaceCodeBlockTypes extends CheckListRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if (RstParser::codeBlockDirectiveIsTypeOf($line, $this->search, true)) {
-            return $this->message;
+            $message = $this->message;
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 
     public static function getDefaultMessage(): string

--- a/src/Rule/Replacement.php
+++ b/src/Rule/Replacement.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class Replacement extends CheckListRule implements LineContentRule
 {
@@ -26,16 +29,23 @@ class Replacement extends CheckListRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($matches = $line->clean()->match($this->search)) {
-            return sprintf($this->message, $matches[0]);
+            $message = sprintf($this->message, $matches[0]);
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 
     public static function getDefaultMessage(): string

--- a/src/Rule/ShortArraySyntax.php
+++ b/src/Rule/ShortArraySyntax.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class ShortArraySyntax extends AbstractRule implements LineContentRule
 {
@@ -23,15 +26,22 @@ class ShortArraySyntax extends AbstractRule implements LineContentRule
         return [RuleGroup::Sonata()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->clean()->match('/[\\s|\()]array\(/')) {
-            return 'Please use short array syntax';
+            $message = 'Please use short array syntax';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/SpaceBeforeSelfXmlClosingTag.php
+++ b/src/Rule/SpaceBeforeSelfXmlClosingTag.php
@@ -15,22 +15,32 @@ namespace App\Rule;
 
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class SpaceBeforeSelfXmlClosingTag extends AbstractRule implements LineContentRule
 {
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current()->raw()->toString();
 
         if (!preg_match('/\/>/', $line)) {
-            return null;
+            return NullViolation::create();
         }
 
         if (!preg_match('/\ \/>/', $line) && !RstParser::isLinkUsage($line)) {
-            return 'Please add space before "/>"';
+            $message = 'Please add space before "/>"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/SpaceBetweenLabelAndLinkInDoc.php
+++ b/src/Rule/SpaceBetweenLabelAndLinkInDoc.php
@@ -17,7 +17,10 @@ use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 use function Symfony\Component\String\u;
 
@@ -38,21 +41,28 @@ class SpaceBetweenLabelAndLinkInDoc extends AbstractRule implements LineContentR
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current()->raw();
 
         if ($matches = $line->match('/:doc:`(?P<label>.*)<(?P<link>.*)>`/')) {
             if (!u($matches['label'])->endsWith(' ')) {
-                return sprintf(
+                $message = sprintf(
                     'Please add a space between "%s" and "<%s>" inside :doc: directive',
                     $matches['label'],
                     $matches['link']
                 );
+
+                return Violation::from(
+                    $message,
+                    $filename,
+                    1,
+                    ''
+                );
             }
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/SpaceBetweenLabelAndLinkInRef.php
+++ b/src/Rule/SpaceBetweenLabelAndLinkInRef.php
@@ -17,7 +17,10 @@ use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 use function Symfony\Component\String\u;
 
@@ -38,21 +41,28 @@ class SpaceBetweenLabelAndLinkInRef extends AbstractRule implements LineContentR
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current()->raw();
 
         if ($matches = $line->match('/:ref:`(?P<label>.*)<(?P<link>.*)>`/')) {
             if (!u($matches['label'])->endsWith(' ')) {
-                return sprintf(
+                $message = sprintf(
                     'Please add a space between "%s" and "<%s>" inside :ref: directive',
                     $matches['label'],
                     $matches['link']
                 );
+
+                return Violation::from(
+                    $message,
+                    $filename,
+                    1,
+                    ''
+                );
             }
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/StringReplacement.php
+++ b/src/Rule/StringReplacement.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class StringReplacement extends CheckListRule implements LineContentRule
 {
@@ -25,16 +28,23 @@ class StringReplacement extends CheckListRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->clean()->containsAny($this->search)) {
-            return sprintf($this->message, $this->search);
+            $message = sprintf($this->message, $this->search);
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 
     /**

--- a/src/Rule/Typo.php
+++ b/src/Rule/Typo.php
@@ -15,7 +15,10 @@ namespace App\Rule;
 
 use App\Annotations\Rule\Description;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Report common typos.")
@@ -30,16 +33,23 @@ class Typo extends CheckListRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current()->raw();
 
         if ($matches = $line->match($this->search)) {
-            return sprintf($this->message, $matches[0]);
+            $message = sprintf($this->message, $matches[0]);
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 
     public static function getDefaultMessage(): string

--- a/src/Rule/UnusedLinks.php
+++ b/src/Rule/UnusedLinks.php
@@ -18,7 +18,10 @@ use App\Rst\RstParser;
 use App\Rst\Value\LinkDefinition;
 use App\Rst\Value\LinkUsage;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -40,7 +43,7 @@ class UnusedLinks extends AbstractRule implements FileContentRule, ResetInterfac
         ];
     }
 
-    public function check(Lines $lines): ?string
+    public function check(Lines $lines, string $filename): ViolationInterface
     {
         /* @todo this should not be needed, make sure its always at position 0 */
         $lines->seek(0);
@@ -71,13 +74,20 @@ class UnusedLinks extends AbstractRule implements FileContentRule, ResetInterfac
         }
 
         if (!empty($this->linkDefinitions)) {
-            return sprintf(
+            $message = sprintf(
                 'The following link definitions aren\'t used anymore and should be removed: "%s"',
                 implode('", "', array_unique(array_keys($this->linkDefinitions)))
             );
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 
     public function reset(): void

--- a/src/Rule/UseHttpsXsdUrls.php
+++ b/src/Rule/UseHttpsXsdUrls.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class UseHttpsXsdUrls extends AbstractRule implements LineContentRule
 {
@@ -26,15 +29,22 @@ class UseHttpsXsdUrls extends AbstractRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($matches = $line->raw()->match('/http\:\/\/([^\s]+)\.xsd/')) {
-            return sprintf('Please use "https" for %s', $matches[0]);
+            $message = sprintf('Please use "https" for %s', $matches[0]);
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/ValidInlineHighlightedNamespaces.php
+++ b/src/Rule/ValidInlineHighlightedNamespaces.php
@@ -18,7 +18,10 @@ use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Helper\PhpHelper;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Ensures to have 2 backslashes when highlighting a namespace to have valid output.")
@@ -39,7 +42,7 @@ class ValidInlineHighlightedNamespaces extends AbstractRule implements LineConte
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
@@ -52,7 +55,14 @@ class ValidInlineHighlightedNamespaces extends AbstractRule implements LineConte
                 }
 
                 if (PhpHelper::isUsingTwoBackslashes($lala = str_replace('``', '', $occurence))) {
-                    return sprintf('Please use 1 backslash when highlighting a namespace with double backticks: %s', $occurence);
+                    $message = sprintf('Please use 1 backslash when highlighting a namespace with double backticks: %s', $occurence);
+
+                    return Violation::from(
+                        $message,
+                        $filename,
+                        1,
+                        ''
+                    );
                 }
             }
 
@@ -66,7 +76,14 @@ class ValidInlineHighlightedNamespaces extends AbstractRule implements LineConte
                 }
 
                 if (!PhpHelper::isUsingTwoBackslashes(str_replace('`', '', $occurence))) {
-                    return sprintf('Please use 2 backslashes when highlighting a namespace with single backticks: %s', $occurence);
+                    $message = sprintf('Please use 2 backslashes when highlighting a namespace with single backticks: %s', $occurence);
+
+                    return Violation::from(
+                        $message,
+                        $filename,
+                        1,
+                        ''
+                    );
                 }
             }
 
@@ -74,6 +91,6 @@ class ValidInlineHighlightedNamespaces extends AbstractRule implements LineConte
         }
 
         end:
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/ValidUseStatements.php
+++ b/src/Rule/ValidUseStatements.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace App\Rule;
 
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 class ValidUseStatements extends AbstractRule implements LineContentRule
 {
@@ -26,7 +29,7 @@ class ValidUseStatements extends AbstractRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
@@ -35,9 +38,16 @@ class ValidUseStatements extends AbstractRule implements LineContentRule
          * @todo do it in one regex instead of regex + string search
          */
         if ($line->clean()->match('/^use (.*);$/') && false !== strpos($line->clean()->toString(), '\\\\')) {
-            return 'Please do not escape the backslashes in a use statement.';
+            $message = 'Please do not escape the backslashes in a use statement.';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/VersionaddedDirectiveMajorVersion.php
+++ b/src/Rule/VersionaddedDirectiveMajorVersion.php
@@ -15,7 +15,10 @@ namespace App\Rule;
 
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 use Composer\Semver\VersionParser;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -53,13 +56,13 @@ class VersionaddedDirectiveMajorVersion extends AbstractRule implements LineCont
         return [RuleGroup::Symfony()];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if (!RstParser::directiveIs($line, RstParser::DIRECTIVE_VERSIONADDED)) {
-            return null;
+            return NullViolation::create();
         }
 
         if (preg_match(sprintf('/^%s(.*)$/', RstParser::DIRECTIVE_VERSIONADDED), $lines->current()->clean()->toString(), $matches)) {
@@ -73,21 +76,35 @@ class VersionaddedDirectiveMajorVersion extends AbstractRule implements LineCont
                 $major = (int) $major;
 
                 if ($this->majorVersion !== $major) {
-                    return sprintf(
+                    $message = sprintf(
                         'You are not allowed to use version "%s". Only major version "%s" is allowed.',
                         $version,
                         $this->majorVersion
                     );
+
+                    return Violation::from(
+                        $message,
+                        $filename,
+                        1,
+                        ''
+                    );
                 }
             } catch (\UnexpectedValueException $e) {
-                return sprintf(
+                $message = sprintf(
                     'Please provide a numeric version behind "%s" instead of "%s"',
                     RstParser::DIRECTIVE_VERSIONADDED,
                     $version
                 );
+
+                return Violation::from(
+                    $message,
+                    $filename,
+                    1,
+                    ''
+                );
             }
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/VersionaddedDirectiveShouldHaveVersion.php
+++ b/src/Rule/VersionaddedDirectiveShouldHaveVersion.php
@@ -18,7 +18,10 @@ use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 use Composer\Semver\VersionParser;
 
 /**
@@ -45,33 +48,47 @@ class VersionaddedDirectiveShouldHaveVersion extends AbstractRule implements Lin
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if (!RstParser::directiveIs($line, RstParser::DIRECTIVE_VERSIONADDED)) {
-            return null;
+            return NullViolation::create();
         }
 
         if (preg_match(sprintf('/^%s(.*)$/', RstParser::DIRECTIVE_VERSIONADDED), $lines->current()->clean()->toString(), $matches)) {
             $version = trim($matches[1]);
 
             if (empty($version)) {
-                return sprintf('Please provide a version behind "%s"', RstParser::DIRECTIVE_VERSIONADDED);
+                $message = sprintf('Please provide a version behind "%s"', RstParser::DIRECTIVE_VERSIONADDED);
+
+                return Violation::from(
+                    $message,
+                    $filename,
+                    1,
+                    ''
+                );
             }
 
             try {
                 $this->versionParser->normalize($version);
             } catch (\UnexpectedValueException $e) {
-                return sprintf(
+                $message = sprintf(
                     'Please provide a numeric version behind "%s" instead of "%s"',
                     RstParser::DIRECTIVE_VERSIONADDED,
                     $version
                 );
+
+                return Violation::from(
+                    $message,
+                    $filename,
+                    1,
+                    ''
+                );
             }
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/YamlInsteadOfYmlSuffix.php
+++ b/src/Rule/YamlInsteadOfYmlSuffix.php
@@ -18,7 +18,10 @@ use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Rst\RstParser;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Make sure to only use `yaml` instead of `yml`.")
@@ -37,23 +40,37 @@ class YamlInsteadOfYmlSuffix extends AbstractRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->raw()->match('/\.travis\.yml/')) {
-            return null;
+            return NullViolation::create();
         }
 
         if (RstParser::codeBlockDirectiveIsTypeOf($line, RstParser::CODE_BLOCK_YML)) {
-            return 'Please use ".. code-block:: yaml" instead of ".. code-block:: yml"';
+            $message = 'Please use ".. code-block:: yaml" instead of ".. code-block:: yml"';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
         if ($matches = $line->raw()->match('/\.yml/i')) {
-            return sprintf('Please use ".yaml" instead of "%s"', $matches[0]);
+            $message = sprintf('Please use ".yaml" instead of "%s"', $matches[0]);
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/YarnDevOptionAtTheEnd.php
+++ b/src/Rule/YarnDevOptionAtTheEnd.php
@@ -17,7 +17,10 @@ use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Value\Lines;
+use App\Value\NullViolation;
 use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Make sure yarn `--dev` option for `add` command is used at the end.")
@@ -36,15 +39,22 @@ class YarnDevOptionAtTheEnd extends AbstractRule implements LineContentRule
         ];
     }
 
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->clean()->match('/yarn add \-\-dev(.*)$/')) {
-            return 'Please move "--dev" option to the end of the command';
+            $message = 'Please move "--dev" option to the end of the command';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Rule/YarnDevOptionNotAtTheEnd.php
+++ b/src/Rule/YarnDevOptionNotAtTheEnd.php
@@ -17,6 +17,9 @@ use App\Annotations\Rule\Description;
 use App\Annotations\Rule\InvalidExample;
 use App\Annotations\Rule\ValidExample;
 use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 /**
  * @Description("Make sure yarn `--dev` option for `add` command is used at the end.")
@@ -27,15 +30,22 @@ use App\Value\Lines;
  */
 class YarnDevOptionNotAtTheEnd extends AbstractRule implements LineContentRule
 {
-    public function check(Lines $lines, int $number): ?string
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);
         $line = $lines->current();
 
         if ($line->clean()->match('/yarn add(.*)\-\-dev$/')) {
-            return 'Please move "--dev" option before the package';
+            $message = 'Please move "--dev" option before the package';
+
+            return Violation::from(
+                $message,
+                $filename,
+                1,
+                ''
+            );
         }
 
-        return null;
+        return NullViolation::create();
     }
 }

--- a/src/Value/NullViolation.php
+++ b/src/Value/NullViolation.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Value;
+
+final class NullViolation implements ViolationInterface
+{
+    private string $message;
+    private string $filename;
+    private int $lineno;
+    private string $rawLine;
+
+    private function __construct()
+    {
+        $this->message = '';
+        $this->filename = '';
+        $this->lineno = 0;
+        $this->rawLine = '';
+    }
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function message(): string
+    {
+        return $this->message;
+    }
+
+    public function filename(): string
+    {
+        return $this->filename;
+    }
+
+    public function lineno(): int
+    {
+        return $this->lineno;
+    }
+
+    public function rawLine(): string
+    {
+        return $this->rawLine;
+    }
+
+    public function isNull(): bool
+    {
+        return true;
+    }
+}

--- a/src/Value/Violation.php
+++ b/src/Value/Violation.php
@@ -15,7 +15,7 @@ namespace App\Value;
 
 use Webmozart\Assert\Assert;
 
-final class Violation
+final class Violation implements ViolationInterface
 {
     private string $message;
     private string $filename;
@@ -63,5 +63,10 @@ final class Violation
     public function rawLine(): string
     {
         return $this->rawLine;
+    }
+
+    public function isNull(): bool
+    {
+        return false;
     }
 }

--- a/src/Value/ViolationInterface.php
+++ b/src/Value/ViolationInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Value;
+
+interface ViolationInterface
+{
+    public function message(): string;
+
+    public function filename(): string;
+
+    public function lineno(): int;
+
+    public function rawLine(): string;
+
+    public function isNull(): bool;
+}

--- a/tests/Rule/ArgumentVariableMustMatchTypeTest.php
+++ b/tests/Rule/ArgumentVariableMustMatchTypeTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\ArgumentVariableMustMatchType;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 
@@ -25,7 +28,7 @@ final class ArgumentVariableMustMatchTypeTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
         $rule = new ArgumentVariableMustMatchType();
         $rule->setOptions([
@@ -41,20 +44,25 @@ final class ArgumentVariableMustMatchTypeTest extends \App\Tests\UnitTestCase
             ],
         ]);
 
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            $rule->check($sample->lines(), $sample->lineNumber())
+            $rule->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         foreach (self::phpCodeBlocks() as $codeBlock) {
             yield [
-                'Please rename "$builder" to "$containerBuilder"',
+                Violation::from(
+                    'Please rename "$builder" to "$containerBuilder"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -63,7 +71,12 @@ final class ArgumentVariableMustMatchTypeTest extends \App\Tests\UnitTestCase
             ];
 
             yield [
-                'Please rename "$builder" to "$containerBuilder". Please rename "$configurator" to "$containerConfigurator"',
+                Violation::from(
+                    'Please rename "$builder" to "$containerBuilder". Please rename "$configurator" to "$containerConfigurator"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -72,7 +85,7 @@ final class ArgumentVariableMustMatchTypeTest extends \App\Tests\UnitTestCase
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -81,7 +94,12 @@ final class ArgumentVariableMustMatchTypeTest extends \App\Tests\UnitTestCase
             ];
 
             yield [
-                'Please rename "$configurator" to "$containerConfigurator"',
+                Violation::from(
+                    'Please rename "$configurator" to "$containerConfigurator"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -90,7 +108,7 @@ final class ArgumentVariableMustMatchTypeTest extends \App\Tests\UnitTestCase
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -99,7 +117,12 @@ final class ArgumentVariableMustMatchTypeTest extends \App\Tests\UnitTestCase
             ];
 
             yield [
-                'Please rename "$configurator" to "$containerConfigurator"',
+                Violation::from(
+                    'Please rename "$configurator" to "$containerConfigurator"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     'some',
@@ -115,7 +138,7 @@ final class ArgumentVariableMustMatchTypeTest extends \App\Tests\UnitTestCase
         }
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
     }

--- a/tests/Rule/BlankLineAfterAnchorTest.php
+++ b/tests/Rule/BlankLineAfterAnchorTest.php
@@ -15,6 +15,8 @@ namespace App\Tests\Rule;
 
 use App\Rule\BlankLineAfterAnchor;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\ViolationInterface;
 
 final class BlankLineAfterAnchorTest extends \App\Tests\UnitTestCase
 {
@@ -23,26 +25,26 @@ final class BlankLineAfterAnchorTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new BlankLineAfterAnchor())->check($sample->lines(), $sample->lineNumber())
+            (new BlankLineAfterAnchor())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '',
                 '.. _env-var-processors:',
@@ -54,7 +56,7 @@ final class BlankLineAfterAnchorTest extends \App\Tests\UnitTestCase
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. _env-var-processors:',
                 '',
@@ -65,7 +67,7 @@ final class BlankLineAfterAnchorTest extends \App\Tests\UnitTestCase
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '',
                 '.. _env-var-processors:',
@@ -78,7 +80,7 @@ final class BlankLineAfterAnchorTest extends \App\Tests\UnitTestCase
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '',
                 '.. _env-var-processors:',
@@ -92,7 +94,7 @@ final class BlankLineAfterAnchorTest extends \App\Tests\UnitTestCase
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. index::',
                 '    single: Deployment; Deployment tools',
@@ -106,7 +108,7 @@ final class BlankLineAfterAnchorTest extends \App\Tests\UnitTestCase
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. index::',
                 '    single: Deployment; Deployment tools',

--- a/tests/Rule/BlankLineAfterColonTest.php
+++ b/tests/Rule/BlankLineAfterColonTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\BlankLineAfterColon;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class BlankLineAfterColonTest extends \App\Tests\UnitTestCase
 {
@@ -23,31 +26,31 @@ final class BlankLineAfterColonTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new BlankLineAfterColon())->check($sample->lines(), $sample->lineNumber())
+            (new BlankLineAfterColon())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp:'),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 'For example:',
                 '',
@@ -56,7 +59,12 @@ final class BlankLineAfterColonTest extends \App\Tests\UnitTestCase
         ];
 
         yield [
-            'Please add a blank line after "For example:"',
+            Violation::from(
+                'Please add a blank line after "For example:"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 'For example:',
                 'For example::',
@@ -64,7 +72,7 @@ final class BlankLineAfterColonTest extends \App\Tests\UnitTestCase
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: yaml',
                 '',
@@ -74,7 +82,7 @@ final class BlankLineAfterColonTest extends \App\Tests\UnitTestCase
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: yml',
                 '    :option:',
@@ -85,7 +93,7 @@ final class BlankLineAfterColonTest extends \App\Tests\UnitTestCase
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '',
                 '.. _env-var-processors:',

--- a/tests/Rule/BlankLineAfterFilepathInCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInCodeBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\BlankLineAfterFilepathInCodeBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCase
 {
@@ -28,32 +31,37 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
      * @dataProvider checkXmlProvider
      * @dataProvider checkTwigProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new BlankLineAfterFilepathInCodeBlock())->check($sample->lines(), $sample->lineNumber())
+            (new BlankLineAfterFilepathInCodeBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkPhpProvider(): \Generator
     {
         yield [
-            'Please add a blank line after "// src/Handler/Collection.php"',
+            Violation::from(
+                'Please add a blank line after "// src/Handler/Collection.php"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: php',
                 '',
@@ -62,7 +70,7 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: php',
                 '',
@@ -74,12 +82,17 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkYmlProvider(): \Generator
     {
         yield [
-            'Please add a blank line after "# config/services.yml"',
+            Violation::from(
+                'Please add a blank line after "# config/services.yml"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: yml',
                 '',
@@ -88,7 +101,7 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: yml',
                 '',
@@ -100,12 +113,17 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkYamlProvider(): \Generator
     {
         yield [
-            'Please add a blank line after "# config/services.yaml"',
+            Violation::from(
+                'Please add a blank line after "# config/services.yaml"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: yaml',
                 '',
@@ -114,7 +132,7 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: yaml',
                 '',
@@ -126,12 +144,17 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkXmlProvider(): \Generator
     {
         yield [
-            'Please add a blank line after "<!-- config/services.xml -->"',
+            Violation::from(
+                'Please add a blank line after "<!-- config/services.xml -->"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: xml',
                 '',
@@ -140,7 +163,7 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: xml',
                 '',
@@ -150,7 +173,12 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
             ]),
         ];
         yield [
-            'Please add a blank line after "<!--config/services.xml-->"',
+            Violation::from(
+                'Please add a blank line after "<!--config/services.xml-->"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: xml',
                 '',
@@ -159,7 +187,7 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: xml',
                 '',
@@ -171,12 +199,17 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkTwigProvider(): \Generator
     {
         yield [
-            'Please add a blank line after "{# templates/index.html.twig #}"',
+            Violation::from(
+                'Please add a blank line after "{# templates/index.html.twig #}"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: twig',
                 '',
@@ -185,7 +218,7 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: twig',
                 '',
@@ -195,7 +228,12 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
             ]),
         ];
         yield [
-            'Please add a blank line after "{# templates/index.html.twig #}"',
+            Violation::from(
+                'Please add a blank line after "{# templates/index.html.twig #}"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: jinja',
                 '',
@@ -204,7 +242,7 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: jinja',
                 '',
@@ -214,7 +252,12 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
             ]),
         ];
         yield [
-            'Please add a blank line after "{# templates/index.html.twig #}"',
+            Violation::from(
+                'Please add a blank line after "{# templates/index.html.twig #}"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: html+jinja',
                 '',
@@ -223,7 +266,7 @@ final class BlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCas
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: html+jinja',
                 '',

--- a/tests/Rule/BlankLineAfterFilepathInPhpCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInPhpCodeBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\BlankLineAfterFilepathInPhpCodeBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class BlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTestCase
 {
@@ -23,22 +26,27 @@ final class BlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTest
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new BlankLineAfterFilepathInPhpCodeBlock())->check($sample->lines(), $sample->lineNumber())
+            (new BlankLineAfterFilepathInPhpCodeBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         foreach (self::phpCodeBlocks() as $codeBlock) {
             yield [
-                'Please add a blank line after "// src/Handler/Collection.php"',
+                Violation::from(
+                    'Please add a blank line after "// src/Handler/Collection.php"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample(
                     [
                         $codeBlock,
@@ -50,7 +58,7 @@ final class BlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTest
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample(
                     [
                         $codeBlock,
@@ -63,7 +71,7 @@ final class BlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTest
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample(
                     [
                         $codeBlock,
@@ -76,7 +84,7 @@ final class BlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTest
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample(
                     [
                         $codeBlock,
@@ -90,7 +98,7 @@ final class BlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTest
         }
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
     }

--- a/tests/Rule/BlankLineAfterFilepathInTwigCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInTwigCodeBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\BlankLineAfterFilepathInTwigCodeBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class BlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitTestCase
 {
@@ -23,21 +26,26 @@ final class BlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitTes
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new BlankLineAfterFilepathInTwigCodeBlock())->check($sample->lines(), $sample->lineNumber())
+            (new BlankLineAfterFilepathInTwigCodeBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            'Please add a blank line after "{# templates/index.html.twig #}"',
+            Violation::from(
+                'Please add a blank line after "{# templates/index.html.twig #}"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: twig',
                 '',
@@ -46,7 +54,7 @@ final class BlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: twig',
                 '',
@@ -56,7 +64,12 @@ final class BlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            'Please add a blank line after "{# templates/index.html.twig #}"',
+            Violation::from(
+                'Please add a blank line after "{# templates/index.html.twig #}"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: jinja',
                 '',
@@ -65,7 +78,7 @@ final class BlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: jinja',
                 '',
@@ -75,7 +88,12 @@ final class BlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            'Please add a blank line after "{# templates/index.html.twig #}"',
+            Violation::from(
+                'Please add a blank line after "{# templates/index.html.twig #}"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: html+jinja',
                 '',
@@ -84,7 +102,7 @@ final class BlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: html+jinja',
                 '',
@@ -94,7 +112,12 @@ final class BlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            'Please add a blank line after "{# templates/index.html.twig #}"',
+            Violation::from(
+                'Please add a blank line after "{# templates/index.html.twig #}"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: html+twig',
                 '',
@@ -103,7 +126,7 @@ final class BlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: html+twig',
                 '',
@@ -113,7 +136,7 @@ final class BlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: html+twig',
                 '',
@@ -123,7 +146,7 @@ final class BlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
     }

--- a/tests/Rule/BlankLineAfterFilepathInXmlCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInXmlCodeBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\BlankLineAfterFilepathInXmlCodeBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class BlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTestCase
 {
@@ -23,16 +26,16 @@ final class BlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTest
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new BlankLineAfterFilepathInXmlCodeBlock())->check($sample->lines(), $sample->lineNumber())
+            (new BlankLineAfterFilepathInXmlCodeBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
@@ -44,7 +47,12 @@ final class BlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTest
 
         foreach ($paths as $path) {
             yield [
-                sprintf('Please add a blank line after "<!-- %s -->"', $path),
+                Violation::from(
+                    sprintf('Please add a blank line after "<!-- %s -->"', $path),
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -54,7 +62,7 @@ final class BlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTest
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -65,7 +73,12 @@ final class BlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTest
             ];
 
             yield [
-                sprintf('Please add a blank line after "<!--%s-->"', $path),
+                Violation::from(
+                    sprintf('Please add a blank line after "<!--%s-->"', $path),
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -75,7 +88,7 @@ final class BlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTest
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -86,7 +99,7 @@ final class BlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTest
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -98,7 +111,7 @@ final class BlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTest
         }
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
     }

--- a/tests/Rule/BlankLineAfterFilepathInYamlCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInYamlCodeBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\BlankLineAfterFilepathInYamlCodeBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class BlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitTestCase
 {
@@ -23,21 +26,26 @@ final class BlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitTes
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new BlankLineAfterFilepathInYamlCodeBlock())->check($sample->lines(), $sample->lineNumber())
+            (new BlankLineAfterFilepathInYamlCodeBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            'Please add a blank line after "# config/services.yml"',
+            Violation::from(
+                'Please add a blank line after "# config/services.yml"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: yml',
                 '',
@@ -46,7 +54,7 @@ final class BlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: yml',
                 '',
@@ -56,7 +64,12 @@ final class BlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            'Please add a blank line after "# config/services.yaml"',
+            Violation::from(
+                'Please add a blank line after "# config/services.yaml"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '.. code-block:: yaml',
                 '',
@@ -65,7 +78,7 @@ final class BlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: yaml',
                 '',
@@ -75,7 +88,7 @@ final class BlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. code-block:: yaml',
                 '',
@@ -85,7 +98,7 @@ final class BlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitTes
             ]),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
     }

--- a/tests/Rule/ComposerDevOptionAtTheEndTest.php
+++ b/tests/Rule/ComposerDevOptionAtTheEndTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\ComposerDevOptionAtTheEnd;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class ComposerDevOptionAtTheEndTest extends \App\Tests\UnitTestCase
 {
@@ -23,25 +26,30 @@ final class ComposerDevOptionAtTheEndTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new ComposerDevOptionAtTheEnd())->check($sample->lines(), $sample->lineNumber())
+            (new ComposerDevOptionAtTheEnd())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            'Please move "--dev" option to the end of the command',
+            Violation::from(
+                'Please move "--dev" option to the end of the command',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample('composer require --dev symfony/debug'),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('composer require symfony/debug --dev'),
         ];
     }

--- a/tests/Rule/ComposerDevOptionNotAtTheEndTest.php
+++ b/tests/Rule/ComposerDevOptionNotAtTheEndTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\ComposerDevOptionNotAtTheEnd;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class ComposerDevOptionNotAtTheEndTest extends \App\Tests\UnitTestCase
 {
@@ -23,25 +26,30 @@ final class ComposerDevOptionNotAtTheEndTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new ComposerDevOptionNotAtTheEnd())->check($sample->lines(), $sample->lineNumber())
+            (new ComposerDevOptionNotAtTheEnd())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('composer require --dev symfony/debug'),
         ];
         yield [
-            'Please move "--dev" option before the package',
+            Violation::from(
+                'Please move "--dev" option before the package',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample('composer require symfony/debug --dev'),
         ];
     }

--- a/tests/Rule/DeprecatedDirectiveShouldHaveVersionTest.php
+++ b/tests/Rule/DeprecatedDirectiveShouldHaveVersionTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\DeprecatedDirectiveShouldHaveVersion;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 use Composer\Semver\VersionParser;
 
 final class DeprecatedDirectiveShouldHaveVersionTest extends \App\Tests\UnitTestCase
@@ -24,42 +27,52 @@ final class DeprecatedDirectiveShouldHaveVersionTest extends \App\Tests\UnitTest
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
             (new DeprecatedDirectiveShouldHaveVersion(new VersionParser()))
-                ->check($sample->lines(), $sample->lineNumber())
+                ->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('.. deprecated:: 1'),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('.. deprecated:: 1.2'),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('.. deprecated:: 1.2.0'),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('.. deprecated:: 1.2   '),
         ];
         yield [
-            'Please provide a version behind ".. deprecated::"',
+            Violation::from(
+                'Please provide a version behind ".. deprecated::"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample('.. deprecated::'),
         ];
         yield [
-            'Please provide a numeric version behind ".. deprecated::" instead of "foo"',
+            Violation::from(
+                'Please provide a numeric version behind ".. deprecated::" instead of "foo"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample('.. deprecated:: foo'),
         ];
     }

--- a/tests/Rule/EnsureExactlyOneSpaceBeforeDirectiveTypeTest.php
+++ b/tests/Rule/EnsureExactlyOneSpaceBeforeDirectiveTypeTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\EnsureExactlyOneSpaceBeforeDirectiveType;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class EnsureExactlyOneSpaceBeforeDirectiveTypeTest extends \App\Tests\UnitTestCase
 {
@@ -24,16 +27,16 @@ final class EnsureExactlyOneSpaceBeforeDirectiveTypeTest extends \App\Tests\Unit
      * @dataProvider validProvider
      * @dataProvider invalidProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new EnsureExactlyOneSpaceBeforeDirectiveType())->check($sample->lines(), $sample->lineNumber())
+            (new EnsureExactlyOneSpaceBeforeDirectiveType())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<string, array{0: null, 1: RstSample}>
+     * @return \Generator<string, array{0: ViolationInterface, 1: RstSample}>
      */
     public function validProvider(): \Generator
     {
@@ -44,14 +47,14 @@ final class EnsureExactlyOneSpaceBeforeDirectiveTypeTest extends \App\Tests\Unit
 
         foreach ($validCases as $validCase) {
             yield $validCase => [
-                null,
+                NullViolation::create(),
                 new RstSample($validCase),
             ];
         }
     }
 
     /**
-     * @return \Generator<string, array{0: string, 1: RstSample}>
+     * @return \Generator<string, array{0: ViolationInterface, 1: RstSample}>
      */
     public function invalidProvider(): \Generator
     {
@@ -63,7 +66,12 @@ final class EnsureExactlyOneSpaceBeforeDirectiveTypeTest extends \App\Tests\Unit
 
         foreach ($invalidCases as $invalidCase) {
             yield $invalidCase => [
-                'Please use only one whitespace between ".." and the directive type.',
+                Violation::from(
+                    'Please use only one whitespace between ".." and the directive type.',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample($invalidCase),
             ];
         }

--- a/tests/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest.php
+++ b/tests/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest extends \App\Tests\UnitTestCase
 {
@@ -24,16 +27,16 @@ final class EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest extends \App\T
      * @dataProvider validProvider
      * @dataProvider invalidProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink())->check($sample->lines(), $sample->lineNumber())
+            (new EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<string, array{0: null, 1: RstSample}>
+     * @return \Generator<string, array{0: ViolationInterface, 1: RstSample}>
      */
     public function validProvider(): \Generator
     {
@@ -45,14 +48,14 @@ final class EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest extends \App\T
 
         foreach ($validCases as $validCase) {
             yield $validCase => [
-                null,
+                NullViolation::create(),
                 new RstSample($validCase),
             ];
         }
     }
 
     /**
-     * @return \Generator<string, array{0: string, 1: RstSample}>
+     * @return \Generator<string, array{0: ViolationInterface, 1: RstSample}>
      */
     public function invalidProvider(): \Generator
     {
@@ -64,7 +67,12 @@ final class EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest extends \App\T
 
         foreach ($invalidCases as $invalidCase) {
             yield $invalidCase => [
-                'Please use only one whitespace between the link definition and the link.',
+                Violation::from(
+                    'Please use only one whitespace between the link definition and the link.',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample($invalidCase),
             ];
         }

--- a/tests/Rule/EnsureLinkDefinitionContainsValidUrlTest.php
+++ b/tests/Rule/EnsureLinkDefinitionContainsValidUrlTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\EnsureLinkDefinitionContainsValidUrl;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class EnsureLinkDefinitionContainsValidUrlTest extends \App\Tests\UnitTestCase
 {
@@ -24,16 +27,16 @@ final class EnsureLinkDefinitionContainsValidUrlTest extends \App\Tests\UnitTest
      * @dataProvider validProvider
      * @dataProvider invalidProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new EnsureLinkDefinitionContainsValidUrl())->check($sample->lines(), $sample->lineNumber())
+            (new EnsureLinkDefinitionContainsValidUrl())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<string, array{0: null, 1: RstSample}>
+     * @return \Generator<string, array{0: ViolationInterface, 1: RstSample}>
      */
     public function validProvider(): \Generator
     {
@@ -49,14 +52,14 @@ final class EnsureLinkDefinitionContainsValidUrlTest extends \App\Tests\UnitTest
 
         foreach ($validCases as $validCase) {
             yield $validCase => [
-                null,
+                NullViolation::create(),
                 new RstSample($validCase),
             ];
         }
     }
 
     /**
-     * @return \Generator<string, array{0: string, 1: RstSample}>
+     * @return \Generator<string, array{0: ViolationInterface, 1: RstSample}>
      */
     public function invalidProvider(): \Generator
     {
@@ -69,9 +72,14 @@ final class EnsureLinkDefinitionContainsValidUrlTest extends \App\Tests\UnitTest
 
         foreach ($invalidCases as $invalidCase) {
             yield $invalidCase => [
-                sprintf(
-                    'Invalid url in "%s"',
-                    $invalidCase
+                Violation::from(
+                    sprintf(
+                        'Invalid url in "%s"',
+                        $invalidCase
+                    ),
+                    'filename',
+                    1,
+                    ''
                 ),
                 new RstSample($invalidCase),
             ];

--- a/tests/Rule/EnsureOrderOfCodeBlocksInConfigurationBlockTest.php
+++ b/tests/Rule/EnsureOrderOfCodeBlocksInConfigurationBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\EnsureOrderOfCodeBlocksInConfigurationBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class EnsureOrderOfCodeBlocksInConfigurationBlockTest extends \App\Tests\UnitTestCase
 {
@@ -24,16 +27,16 @@ final class EnsureOrderOfCodeBlocksInConfigurationBlockTest extends \App\Tests\U
      * @dataProvider validProvider
      * @dataProvider invalidProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new EnsureOrderOfCodeBlocksInConfigurationBlock())->check($sample->lines(), $sample->lineNumber())
+            (new EnsureOrderOfCodeBlocksInConfigurationBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function validProvider(): \Generator
     {
@@ -223,37 +226,37 @@ RST;
 RST;
 
         yield 'valid 1' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid),
         ];
         yield 'valid 2' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid2),
         ];
         yield 'valid 3' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid3),
         ];
         yield 'first invalid, but valid because of xliff' => [
-            null,
+            NullViolation::create(),
             new RstSample($invalid_but_valid_because_of_xliff),
         ];
         yield 'valid too with xliff' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid_too_with_xliff),
         ];
         yield 'valid all the same' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid_all_the_same),
         ];
         yield 'translation debug' => [
-            null,
+            NullViolation::create(),
             new RstSample($translationDebug),
         ];
     }
 
     /**
-     * @return \Generator<array{0: string, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function invalidProvider(): \Generator
     {
@@ -318,15 +321,30 @@ RST;
 RST;
 
         yield [
-            'Please use the following order for your code blocks: "php-annotations, yaml, xml, php"',
+            Violation::from(
+                'Please use the following order for your code blocks: "php-annotations, yaml, xml, php"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample($invalid),
         ];
         yield [
-            'Please use the following order for your code blocks: "php-annotations, php-attributes, yaml, xml, php"',
+            Violation::from(
+                'Please use the following order for your code blocks: "php-annotations, php-attributes, yaml, xml, php"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample($invalid2),
         ];
         yield [
-            'Please use the following order for your code blocks: "php-symfony, php-standalone"',
+            Violation::from(
+                'Please use the following order for your code blocks: "php-symfony, php-standalone"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample($invalid3),
         ];
     }

--- a/tests/Rule/ExtendAbstractAdminTest.php
+++ b/tests/Rule/ExtendAbstractAdminTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\ExtendAbstractAdmin;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class ExtendAbstractAdminTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class ExtendAbstractAdminTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new ExtendAbstractAdmin())->check($sample->lines(), $sample->lineNumber())
+            (new ExtendAbstractAdmin())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,36 +38,56 @@ final class ExtendAbstractAdminTest extends \App\Tests\UnitTestCase
     {
         return [
             [
-                'Please extend AbstractAdmin instead of Admin',
+                Violation::from(
+                    'Please extend AbstractAdmin instead of Admin',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('class TestAdmin extends Admin'),
             ],
 
             [
-                'Please extend AbstractAdmin instead of Admin',
+                Violation::from(
+                    'Please extend AbstractAdmin instead of Admin',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('    class TestAdmin extends Admin'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('class TestAdmin extends AbstractAdmin'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('    class TestAdmin extends AbstractAdmin'),
             ],
             [
-                'Please use "Sonata\AdminBundle\Admin\AbstractAdmin" instead of "Sonata\AdminBundle\Admin\Admin"',
+                Violation::from(
+                    'Please use "Sonata\AdminBundle\Admin\AbstractAdmin" instead of "Sonata\AdminBundle\Admin\Admin"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('use Sonata\AdminBundle\Admin\Admin;'),
             ],
             [
-                'Please use "Sonata\AdminBundle\Admin\AbstractAdmin" instead of "Sonata\AdminBundle\Admin\Admin"',
+                Violation::from(
+                    'Please use "Sonata\AdminBundle\Admin\AbstractAdmin" instead of "Sonata\AdminBundle\Admin\Admin"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('    use Sonata\AdminBundle\Admin\Admin;'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('use Sonata\AdminBundle\Admin\AbstractAdmin;'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('    use Sonata\AdminBundle\Admin\AbstractAdmin;'),
             ],
         ];

--- a/tests/Rule/ExtendAbstractControllerTest.php
+++ b/tests/Rule/ExtendAbstractControllerTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\ExtendAbstractController;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class ExtendAbstractControllerTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class ExtendAbstractControllerTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new ExtendAbstractController())->check($sample->lines(), $sample->lineNumber())
+            (new ExtendAbstractController())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,37 +38,57 @@ final class ExtendAbstractControllerTest extends \App\Tests\UnitTestCase
     {
         return [
             [
-                'Please extend AbstractController instead of Controller',
+                Violation::from(
+                    'Please extend AbstractController instead of Controller',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('class TestController extends Controller'),
             ],
 
             [
-                'Please extend AbstractController instead of Controller',
+                Violation::from(
+                    'Please extend AbstractController instead of Controller',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('    class TestController extends Controller'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('class TestController extends AbstractController'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('    class TestController extends AbstractController'),
             ],
             [
-                'Please use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead of "Symfony\Bundle\FrameworkBundle\Controller\Controller"',
+                Violation::from(
+                    'Please use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead of "Symfony\Bundle\FrameworkBundle\Controller\Controller"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('use Symfony\Bundle\FrameworkBundle\Controller\Controller;'),
             ],
 
             [
-                'Please use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead of "Symfony\Bundle\FrameworkBundle\Controller\Controller"',
+                Violation::from(
+                    'Please use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead of "Symfony\Bundle\FrameworkBundle\Controller\Controller"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('    use Symfony\Bundle\FrameworkBundle\Controller\Controller;'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;'),
             ],
         ];

--- a/tests/Rule/ExtendControllerTest.php
+++ b/tests/Rule/ExtendControllerTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\ExtendController;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class ExtendControllerTest extends \App\Tests\UnitTestCase
 {
@@ -23,52 +26,72 @@ final class ExtendControllerTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new ExtendController())->check($sample->lines(), $sample->lineNumber())
+            (new ExtendController())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return array<array{0: string|null, 1: RstSample}>
+     * @return array<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): array
     {
         return [
             [
-                'Please extend Controller instead of AbstractController',
+                Violation::from(
+                    'Please extend Controller instead of AbstractController',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('class TestController extends AbstractController'),
             ],
 
             [
-                'Please extend Controller instead of AbstractController',
+                Violation::from(
+                    'Please extend Controller instead of AbstractController',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('    class TestController extends AbstractController'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('class TestController extends Controller'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('    class TestController extends Controller'),
             ],
             [
-                'Please use "Symfony\Bundle\FrameworkBundle\Controller\Controller" instead of "Symfony\Bundle\FrameworkBundle\Controller\AbstractController"',
+                Violation::from(
+                    'Please use "Symfony\Bundle\FrameworkBundle\Controller\Controller" instead of "Symfony\Bundle\FrameworkBundle\Controller\AbstractController"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;'),
             ],
 
             [
-                'Please use "Symfony\Bundle\FrameworkBundle\Controller\Controller" instead of "Symfony\Bundle\FrameworkBundle\Controller\AbstractController"',
+                Violation::from(
+                    'Please use "Symfony\Bundle\FrameworkBundle\Controller\Controller" instead of "Symfony\Bundle\FrameworkBundle\Controller\AbstractController"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('use Symfony\Bundle\FrameworkBundle\Controller\Controller;'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('    use Symfony\Bundle\FrameworkBundle\Controller\Controller;'),
             ],
         ];

--- a/tests/Rule/ExtensionXlfInsteadOfXliffTest.php
+++ b/tests/Rule/ExtensionXlfInsteadOfXliffTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\ExtensionXlfInsteadOfXliff;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class ExtensionXlfInsteadOfXliffTest extends \App\Tests\UnitTestCase
 {
@@ -23,26 +26,31 @@ final class ExtensionXlfInsteadOfXliffTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new ExtensionXlfInsteadOfXliff())->check($sample->lines(), $sample->lineNumber())
+            (new ExtensionXlfInsteadOfXliff())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return array<array{0: string|null, 1: RstSample}>
+     * @return array<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): array
     {
         return [
             [
-                'Please use ".xlf" extension instead of ".xliff"',
+                Violation::from(
+                    'Please use ".xlf" extension instead of ".xliff"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('messages.xliff'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('messages.xlf'),
             ],
         ];

--- a/tests/Rule/FilenameUsesDashesOnlyTest.php
+++ b/tests/Rule/FilenameUsesDashesOnlyTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\FilenameUsesDashesOnly;
 use App\Tests\UnitTestCase;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class FilenameUsesDashesOnlyTest extends UnitTestCase
 {
@@ -24,45 +27,55 @@ final class FilenameUsesDashesOnlyTest extends UnitTestCase
      * @dataProvider validProvider
      * @dataProvider invalidProvider
      */
-    public function check(?string $expected, string $filename): void
+    public function check(ViolationInterface $expected, string $filename): void
     {
         $fileInfo = $this->createMock(\SplFileInfo::class);
         $fileInfo->method('getFilename')->willReturn($filename);
 
-        static::assertSame(
+        static::assertEquals(
             $expected,
             (new FilenameUsesDashesOnly())->check($fileInfo)
         );
     }
 
     /**
-     * @return \Generator<array{0: null, 1: string}>
+     * @return \Generator<array{0: ViolationInterface, 1: string}>
      */
     public function validProvider(): \Generator
     {
         yield [
-            null,
+            NullViolation::create(),
             'custom-extensions.rst',
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             '_custom-extensions.rst',
         ];
     }
 
     /**
-     * @return \Generator<array{0: string, 1: string}>
+     * @return \Generator<array{0: ViolationInterface, 1: string}>
      */
     public function invalidProvider(): \Generator
     {
         yield [
-            'Please use dashes (-) for the filename: custom_extensions.rst',
+            Violation::from(
+                'Please use dashes (-) for the filename: custom_extensions.rst',
+                'custom_extensions.rst',
+                1,
+                ''
+            ),
             'custom_extensions.rst',
         ];
 
         yield [
-            'Please use dashes (-) for the filename: _custom_extensions.rst',
+            Violation::from(
+                'Please use dashes (-) for the filename: _custom_extensions.rst',
+                '_custom_extensions.rst',
+                1,
+                ''
+            ),
             '_custom_extensions.rst',
         ];
     }

--- a/tests/Rule/FilenameUsesUnderscoresOnlyTest.php
+++ b/tests/Rule/FilenameUsesUnderscoresOnlyTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\FilenameUsesUnderscoresOnly;
 use App\Tests\UnitTestCase;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class FilenameUsesUnderscoresOnlyTest extends UnitTestCase
 {
@@ -24,45 +27,56 @@ final class FilenameUsesUnderscoresOnlyTest extends UnitTestCase
      * @dataProvider validProvider
      * @dataProvider invalidProvider
      */
-    public function check(?string $expected, string $filename): void
+    public function check(ViolationInterface $expected, string $filename): void
     {
         $fileInfo = $this->createMock(\SplFileInfo::class);
         $fileInfo->method('getFilename')->willReturn($filename);
 
-        static::assertSame(
+        $violation = (new FilenameUsesUnderscoresOnly())->check($fileInfo);
+        static::assertEquals(
             $expected,
-            (new FilenameUsesUnderscoresOnly())->check($fileInfo)
+            $violation
         );
     }
 
     /**
-     * @return \Generator<array{0: null, 1: string}>
+     * @return \Generator<array{0: ViolationInterface, 1: string}>
      */
     public function validProvider(): \Generator
     {
         yield [
-            null,
+            NullViolation::create(),
             'custom_extensions.rst',
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             '_custom_extensions.rst',
         ];
     }
 
     /**
-     * @return \Generator<array{0: string, 1: string}>
+     * @return \Generator<array{0: ViolationInterface, 1: string}>
      */
     public function invalidProvider(): \Generator
     {
         yield [
-            'Please use underscores (_) for the filename: custom-extensions.rst',
+            Violation::from(
+                'Please use underscores (_) for the filename: custom-extensions.rst',
+                'custom-extensions.rst',
+                1,
+                ''
+            ),
             'custom-extensions.rst',
         ];
 
         yield [
-            'Please use underscores (_) for the filename: _custom-extensions.rst',
+            Violation::from(
+                'Please use underscores (_) for the filename: _custom-extensions.rst',
+                '_custom-extensions.rst',
+                1,
+                ''
+            ),
             '_custom-extensions.rst',
         ];
     }

--- a/tests/Rule/FinalAdminClassesTest.php
+++ b/tests/Rule/FinalAdminClassesTest.php
@@ -15,7 +15,10 @@ namespace App\Tests\Rule;
 
 use App\Rule\FinalAdminClasses;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
 use App\Value\RuleName;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class FinalAdminClassesTest extends \App\Tests\UnitTestCase
 {
@@ -33,31 +36,41 @@ final class FinalAdminClassesTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new FinalAdminClasses())->check($sample->lines(), $sample->lineNumber())
+            (new FinalAdminClasses())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return array<array{0: string|null, 1: RstSample}>
+     * @return array<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): array
     {
         return [
             [
-                'Please use "final" for Admin class',
+                Violation::from(
+                    'Please use "final" for Admin class',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('class TestAdmin extends AbstractAdmin'),
             ],
 
             [
-                'Please use "final" for Admin class',
+                Violation::from(
+                    'Please use "final" for Admin class',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('    class TestAdmin extends AbstractAdmin'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('final class TestAdmin extends AbstractAdmin'),
             ],
         ];

--- a/tests/Rule/FinalAdminExtensionClassesTest.php
+++ b/tests/Rule/FinalAdminExtensionClassesTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\FinalAdminExtensionClasses;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class FinalAdminExtensionClassesTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class FinalAdminExtensionClassesTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new FinalAdminExtensionClasses())->check($sample->lines(), $sample->lineNumber())
+            (new FinalAdminExtensionClasses())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,15 +38,25 @@ final class FinalAdminExtensionClassesTest extends \App\Tests\UnitTestCase
     {
         return [
             [
-                'Please use "final" for AdminExtension class',
+                Violation::from(
+                    'Please use "final" for AdminExtension class',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('class TestExtension extends AbstractAdminExtension'),
             ],
             [
-                'Please use "final" for AdminExtension class',
+                Violation::from(
+                    'Please use "final" for AdminExtension class',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('    class TestExtension extends AbstractAdminExtension'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('final class TestExtension extends AbstractAdminExtension'),
             ],
         ];

--- a/tests/Rule/IndentionTest.php
+++ b/tests/Rule/IndentionTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\Indention;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class IndentionTest extends \App\Tests\UnitTestCase
 {
@@ -23,19 +26,19 @@ final class IndentionTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, int $size, RstSample $sample): void
+    public function check(ViolationInterface $expected, int $size, RstSample $sample): void
     {
         $rule = (new Indention());
         $rule->setOptions(['size' => $size]);
 
-        static::assertSame($expected, $rule->check($sample->lines(), $sample->lineNumber()));
+        static::assertEquals($expected, $rule->check($sample->lines(), $sample->lineNumber(), 'filename'));
     }
 
     public function checkProvider(): \Generator
     {
-        yield [null, 4, new RstSample('')];
+        yield [NullViolation::create(), 4, new RstSample('')];
         yield [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<RST
 Headline
@@ -46,7 +49,7 @@ RST
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<RST
 Headline
@@ -56,7 +59,7 @@ RST
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<RST
 Headline
@@ -66,7 +69,12 @@ RST
         ];
 
         yield 'wrong without blank line' => [
-            'Please add 4 spaces for every indention.',
+            Violation::from(
+                'Please add 4 spaces for every indention.',
+                'filename',
+                1,
+                ''
+            ),
             4,
             new RstSample(<<<RST
 Headline
@@ -77,7 +85,12 @@ RST
         ];
 
         yield 'wrong with blank line' => [
-            'Please add 4 spaces for every indention.',
+            Violation::from(
+                'Please add 4 spaces for every indention.',
+                'filename',
+                1,
+                ''
+            ),
             4,
             new RstSample(<<<RST
 Headline
@@ -89,7 +102,7 @@ RST
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<RST
 .. index::
@@ -116,25 +129,30 @@ Code here::
 RST;
 
         yield 'first line of the php comment' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample($php_comment_example, 4),
         ];
 
         yield 'middle of the php comment' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample($php_comment_example, 5),
         ];
 
         yield 'last line of the php comment' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample($php_comment_example, 6),
         ];
 
         yield 'wrong indention in php DocBlock' => [
-            'Please fix the indention of the PHP DocBlock.',
+            Violation::from(
+                'Please fix the indention of the PHP DocBlock.',
+                'filename',
+                1,
+                ''
+            ),
             4,
             new RstSample(<<<'RST'
 Code here::
@@ -151,7 +169,7 @@ RST
         ];
 
         yield 'valid multiline php comment' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 Code here::
@@ -169,7 +187,7 @@ RST
         ];
 
         yield 'valid multiline php comment 2' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 Code here::
@@ -187,7 +205,7 @@ RST
         ];
 
         yield 'valid multiline php comment 3' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 Code here::
@@ -207,7 +225,7 @@ RST
         ];
 
         yield 'list item (#) first line' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 #. At the beginning of the request, the Firewall checks the firewall map
@@ -217,7 +235,7 @@ RST
         ];
 
         yield 'list item (#) second line' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 #. At the beginning of the request, the Firewall checks the firewall map
@@ -227,7 +245,7 @@ RST
         ];
 
         yield 'list item (*) first line' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 * At the beginning of the request, the Firewall checks the firewall map
@@ -237,7 +255,7 @@ RST
         ];
 
         yield 'list item (*) second line' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 * At the beginning of the request, the Firewall checks the firewall map
@@ -247,7 +265,7 @@ RST
         ];
 
         yield 'comment (rst) first line' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 .. I am a comment
@@ -257,7 +275,7 @@ RST
         ];
 
         yield 'comment (rst) second line' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 .. I am a comment
@@ -267,7 +285,7 @@ RST
         ];
 
         yield 'special char "├─"' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
   ├─ app.php
@@ -276,7 +294,7 @@ RST
         ];
 
         yield 'special char "└─"' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
   └─ ...
@@ -285,7 +303,7 @@ RST
         ];
 
         yield 'twig multiline comment' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 .. code-block:: twig
@@ -297,7 +315,7 @@ RST
         ];
 
         yield 'twig multiline comment on second level' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 Info here:
@@ -311,7 +329,7 @@ RST
         ];
 
         yield 'xml multiline comment' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 .. code-block:: xml
@@ -331,7 +349,7 @@ RST
         ];
 
         yield 'yaml array' => [
-            null,
+            NullViolation::create(),
             4,
             new RstSample(<<<'RST'
 .. code-block:: yaml

--- a/tests/Rule/KernelInsteadOfAppKernelTest.php
+++ b/tests/Rule/KernelInsteadOfAppKernelTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\KernelInsteadOfAppKernel;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class KernelInsteadOfAppKernelTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class KernelInsteadOfAppKernelTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new KernelInsteadOfAppKernel())->check($sample->lines(), $sample->lineNumber())
+            (new KernelInsteadOfAppKernel())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,19 +38,29 @@ final class KernelInsteadOfAppKernelTest extends \App\Tests\UnitTestCase
     {
         return [
             [
-                'Please use "src/Kernel.php" instead of "app/AppKernel.php"',
+                Violation::from(
+                    'Please use "src/Kernel.php" instead of "app/AppKernel.php"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('register the bundle in app/AppKernel.php'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('register the bundle in src/Kernel.php'),
             ],
             [
-                'Please use "Kernel" instead of "AppKernel"',
+                Violation::from(
+                    'Please use "Kernel" instead of "AppKernel"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('register the bundle via AppKernel'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('register the bundle via Kernel'),
             ],
         ];

--- a/tests/Rule/LineLengthTest.php
+++ b/tests/Rule/LineLengthTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\LineLength;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class LineLengthTest extends \App\Tests\UnitTestCase
 {
@@ -23,24 +26,29 @@ final class LineLengthTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, int $max, RstSample $sample): void
+    public function check(ViolationInterface $expected, int $max, RstSample $sample): void
     {
         $rule = (new LineLength());
         $rule->setOptions(['max' => $max]);
 
-        static::assertSame($expected, $rule->check($sample->lines(), $sample->lineNumber()));
+        static::assertEquals($expected, $rule->check($sample->lines(), $sample->lineNumber(), 'filename'));
     }
 
     public function checkProvider(): array
     {
         return [
             [
-                'Line is to long (max 20) currently: 23',
+                Violation::from(
+                    'Line is to long (max 20) currently: 23',
+                    'filename',
+                    1,
+                    ''
+                ),
                 20,
                 new RstSample('This is a cool sentence'),
             ],
             [
-                null,
+                NullViolation::create(),
                 20,
                 new RstSample('This is a sentence'),
             ],

--- a/tests/Rule/MaxBlankLinesTest.php
+++ b/tests/Rule/MaxBlankLinesTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\MaxBlankLines;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class MaxBlankLinesTest extends \App\Tests\UnitTestCase
 {
@@ -23,23 +26,28 @@ final class MaxBlankLinesTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, int $max, RstSample $sample): void
+    public function check(ViolationInterface $expected, int $max, RstSample $sample): void
     {
         $rule = (new MaxBlankLines());
         $rule->setOptions(['max' => $max]);
 
-        static::assertSame($expected, $rule->check($sample->lines(), $sample->lineNumber()));
+        static::assertEquals($expected, $rule->check($sample->lines(), $sample->lineNumber(), 'filename'));
     }
 
     public function checkProvider(): \Generator
     {
-        yield [null, 2, new RstSample('')];
-        yield [null, 2, new RstSample([
+        yield [NullViolation::create(), 2, new RstSample('')];
+        yield [NullViolation::create(), 2, new RstSample([
             '',
             '',
         ])];
         yield [
-            'Please use max 2 blank lines, you used 3',
+            Violation::from(
+                'Please use max 2 blank lines, you used 3',
+                'filename',
+                1,
+                ''
+            ),
             2,
             new RstSample([
                 '',
@@ -48,7 +56,12 @@ final class MaxBlankLinesTest extends \App\Tests\UnitTestCase
             ]),
         ];
         yield [
-            'Please use max 1 blank lines, you used 2',
+            Violation::from(
+                'Please use max 1 blank lines, you used 2',
+                'filename',
+                1,
+                ''
+            ),
             1,
             new RstSample([
                 '',
@@ -75,7 +88,12 @@ Learn more about Routing
 RST;
 
         yield [
-            'Please use max 2 blank lines, you used 3',
+            Violation::from(
+                'Please use max 2 blank lines, you used 3',
+                'filename',
+                1,
+                ''
+            ),
             2,
             new RstSample($invalid, 8),
         ];

--- a/tests/Rule/MaxColonsTest.php
+++ b/tests/Rule/MaxColonsTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\MaxColons;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class MaxColonsTest extends \App\Tests\UnitTestCase
 {
@@ -23,46 +26,61 @@ final class MaxColonsTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new MaxColons())->check($sample->lines(), $sample->lineNumber())
+            (new MaxColons())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp:'),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp::'),
         ];
 
         yield [
-            'Please use max 2 colons at the end.',
+            Violation::from(
+                'Please use max 2 colons at the end.',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample('temp:::'),
         ];
 
         yield [
-            'Please use max 2 colons at the end.',
+            Violation::from(
+                'Please use max 2 colons at the end.',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample(' temp:::'),
         ];
 
         yield [
-            'Please use max 2 colons at the end.',
+            Violation::from(
+                'Please use max 2 colons at the end.',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample(' temp::: '),
         ];
     }

--- a/tests/Rule/NoAdminYamlTest.php
+++ b/tests/Rule/NoAdminYamlTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoAdminYaml;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoAdminYamlTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class NoAdminYamlTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoAdminYaml())->check($sample->lines(), $sample->lineNumber())
+            (new NoAdminYaml())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,31 +38,41 @@ final class NoAdminYamlTest extends \App\Tests\UnitTestCase
     {
         return [
             [
-                'Please use "services.yaml" instead of "admin.yml"',
+                Violation::from(
+                    'Please use "services.yaml" instead of "admin.yml"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('register the admin class in admin.yml'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('register the admin class in services.yaml'),
             ],
             [
-                'Please use "services.yaml" instead of "admin.yaml"',
+                Violation::from(
+                    'Please use "services.yaml" instead of "admin.yaml"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('register the admin class in admin.yaml'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('register the admin class in services.yaml'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('# config/packages/sonata_admin.yaml'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('# config/packages/sonata_doctrine_orm_admin.yaml'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('# config/packages/sonata_doctrine_mongodb_admin.yaml'),
             ],
         ];

--- a/tests/Rule/NoBashPromptTest.php
+++ b/tests/Rule/NoBashPromptTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoBashPrompt;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoBashPromptTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class NoBashPromptTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoBashPrompt())->check($sample->lines(), $sample->lineNumber())
+            (new NoBashPrompt())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,7 +38,12 @@ final class NoBashPromptTest extends \App\Tests\UnitTestCase
     {
         return [
             [
-                'Please remove the "$" prefix in .. code-block:: directive',
+                Violation::from(
+                    'Please remove the "$" prefix in .. code-block:: directive',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: bash',
                     '',
@@ -43,7 +51,12 @@ final class NoBashPromptTest extends \App\Tests\UnitTestCase
                 ]),
             ],
             [
-                'Please remove the "$" prefix in .. code-block:: directive',
+                Violation::from(
+                    'Please remove the "$" prefix in .. code-block:: directive',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: shell',
                     '',
@@ -51,7 +64,12 @@ final class NoBashPromptTest extends \App\Tests\UnitTestCase
                 ]),
             ],
             [
-                'Please remove the "$" prefix in .. code-block:: directive',
+                Violation::from(
+                    'Please remove the "$" prefix in .. code-block:: directive',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: terminal',
                     '',
@@ -59,11 +77,11 @@ final class NoBashPromptTest extends \App\Tests\UnitTestCase
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('$ composer install sonata-project/admin-bundle'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('composer install sonata-project/admin-bundle'),
             ],
         ];

--- a/tests/Rule/NoBlankLineAfterFilepathInCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInCodeBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoBlankLineAfterFilepathInCodeBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestCase
 {
@@ -28,11 +31,11 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
      * @dataProvider checkXmlProvider
      * @dataProvider checkTwigProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoBlankLineAfterFilepathInCodeBlock())->check($sample->lines(), $sample->lineNumber())
+            (new NoBlankLineAfterFilepathInCodeBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -40,7 +43,7 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
     {
         return [
             [
-                null,
+                NullViolation::create(),
                 new RstSample('temp'),
             ],
         ];
@@ -50,7 +53,12 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
     {
         return [
             [
-                'Please remove blank line after "// src/Handler/Collection.php"',
+                Violation::from(
+                    'Please remove blank line after "// src/Handler/Collection.php"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: php',
                     '',
@@ -60,7 +68,7 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: php',
                     '',
@@ -75,7 +83,12 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
     {
         return [
             [
-                'Please remove blank line after "# config/services.yml"',
+                Violation::from(
+                    'Please remove blank line after "# config/services.yml"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: yml',
                     '',
@@ -85,7 +98,7 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: yml',
                     '',
@@ -100,7 +113,12 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
     {
         return [
             [
-                'Please remove blank line after "# config/services.yaml"',
+                Violation::from(
+                    'Please remove blank line after "# config/services.yaml"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: yaml',
                     '',
@@ -110,7 +128,7 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: yaml',
                     '',
@@ -125,7 +143,12 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
     {
         return [
             [
-                'Please remove blank line after "<!-- config/services.xml -->"',
+                Violation::from(
+                    'Please remove blank line after "<!-- config/services.xml -->"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -135,7 +158,7 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -144,7 +167,12 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
                 ]),
             ],
             [
-                'Please remove blank line after "<!--config/services.xml-->"',
+                Violation::from(
+                    'Please remove blank line after "<!--config/services.xml-->"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -154,7 +182,7 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -169,7 +197,12 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
     {
         return [
             [
-                'Please remove blank line after "{# templates/index.html.twig #}"',
+                Violation::from(
+                    'Please remove blank line after "{# templates/index.html.twig #}"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: twig',
                     '',
@@ -179,7 +212,7 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: twig',
                     '',
@@ -188,7 +221,12 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
                 ]),
             ],
             [
-                'Please remove blank line after "{# templates/index.html.twig #}"',
+                Violation::from(
+                    'Please remove blank line after "{# templates/index.html.twig #}"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: jinja',
                     '',
@@ -198,7 +236,7 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: jinja',
                     '',
@@ -207,7 +245,12 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
                 ]),
             ],
             [
-                'Please remove blank line after "{# templates/index.html.twig #}"',
+                Violation::from(
+                    'Please remove blank line after "{# templates/index.html.twig #}"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: html+jinja',
                     '',
@@ -217,7 +260,7 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends \App\Tests\UnitTestC
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: html+jinja',
                     '',

--- a/tests/Rule/NoBlankLineAfterFilepathInPhpCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInPhpCodeBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoBlankLineAfterFilepathInPhpCodeBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoBlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class NoBlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTe
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoBlankLineAfterFilepathInPhpCodeBlock())->check($sample->lines(), $sample->lineNumber())
+            (new NoBlankLineAfterFilepathInPhpCodeBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,7 +38,12 @@ final class NoBlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTe
     {
         foreach (self::phpCodeBlocks() as $codeBlock) {
             yield [
-                'Please remove blank line after "// src/Handler/Collection.php"',
+                Violation::from(
+                    'Please remove blank line after "// src/Handler/Collection.php"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -46,7 +54,7 @@ final class NoBlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTe
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -56,7 +64,7 @@ final class NoBlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTe
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -68,7 +76,7 @@ final class NoBlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTe
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -81,7 +89,7 @@ final class NoBlankLineAfterFilepathInPhpCodeBlockTest extends \App\Tests\UnitTe
         }
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
     }

--- a/tests/Rule/NoBlankLineAfterFilepathInTwigCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInTwigCodeBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoBlankLineAfterFilepathInTwigCodeBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitT
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoBlankLineAfterFilepathInTwigCodeBlock())->check($sample->lines(), $sample->lineNumber())
+            (new NoBlankLineAfterFilepathInTwigCodeBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,7 +38,12 @@ final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitT
     {
         return [
             [
-                'Please remove blank line after "{# templates/index.html.twig #}"',
+                Violation::from(
+                    'Please remove blank line after "{# templates/index.html.twig #}"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: twig',
                     '',
@@ -45,7 +53,7 @@ final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: twig',
                     '',
@@ -54,7 +62,12 @@ final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                'Please remove blank line after "{# templates/index.html.twig #}"',
+                Violation::from(
+                    'Please remove blank line after "{# templates/index.html.twig #}"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: jinja',
                     '',
@@ -64,7 +77,7 @@ final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: jinja',
                     '',
@@ -73,7 +86,12 @@ final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                'Please remove blank line after "{# templates/index.html.twig #}"',
+                Violation::from(
+                    'Please remove blank line after "{# templates/index.html.twig #}"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: html+jinja',
                     '',
@@ -83,7 +101,7 @@ final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: html+jinja',
                     '',
@@ -92,7 +110,12 @@ final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                'Please remove blank line after "{# templates/index.html.twig #}"',
+                Violation::from(
+                    'Please remove blank line after "{# templates/index.html.twig #}"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: html+twig',
                     '',
@@ -102,7 +125,7 @@ final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: html+twig',
                     '',
@@ -113,7 +136,7 @@ final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: html+twig',
                     '',
@@ -122,7 +145,7 @@ final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('temp'),
             ],
         ];

--- a/tests/Rule/NoBlankLineAfterFilepathInXmlCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInXmlCodeBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoBlankLineAfterFilepathInXmlCodeBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoBlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class NoBlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTe
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoBlankLineAfterFilepathInXmlCodeBlock())->check($sample->lines(), $sample->lineNumber())
+            (new NoBlankLineAfterFilepathInXmlCodeBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -41,7 +44,12 @@ final class NoBlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTe
 
         foreach ($paths as $path) {
             yield [
-                sprintf('Please remove blank line after "<!-- %s -->"', $path),
+                Violation::from(
+                    sprintf('Please remove blank line after "<!-- %s -->"', $path),
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -52,7 +60,7 @@ final class NoBlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTe
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -62,7 +70,12 @@ final class NoBlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTe
             ];
 
             yield [
-                sprintf('Please remove blank line after "<!--%s-->"', $path),
+                Violation::from(
+                    sprintf('Please remove blank line after "<!--%s-->"', $path),
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -73,7 +86,7 @@ final class NoBlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTe
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -86,7 +99,7 @@ final class NoBlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTe
             ];
 
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: xml',
                     '',
@@ -97,7 +110,7 @@ final class NoBlankLineAfterFilepathInXmlCodeBlockTest extends \App\Tests\UnitTe
         }
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
     }

--- a/tests/Rule/NoBlankLineAfterFilepathInYamlCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInYamlCodeBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoBlankLineAfterFilepathInYamlCodeBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoBlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class NoBlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitT
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoBlankLineAfterFilepathInYamlCodeBlock())->check($sample->lines(), $sample->lineNumber())
+            (new NoBlankLineAfterFilepathInYamlCodeBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,7 +38,12 @@ final class NoBlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitT
     {
         return [
             [
-                'Please remove blank line after "# config/services.yml"',
+                Violation::from(
+                    'Please remove blank line after "# config/services.yml"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: yml',
                     '',
@@ -45,7 +53,7 @@ final class NoBlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: yml',
                     '',
@@ -54,7 +62,12 @@ final class NoBlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                'Please remove blank line after "# config/services.yaml"',
+                Violation::from(
+                    'Please remove blank line after "# config/services.yaml"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. code-block:: yaml',
                     '',
@@ -64,7 +77,7 @@ final class NoBlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: yaml',
                     '',
@@ -75,7 +88,7 @@ final class NoBlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. code-block:: yaml',
                     '',
@@ -84,7 +97,7 @@ final class NoBlankLineAfterFilepathInYamlCodeBlockTest extends \App\Tests\UnitT
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('temp'),
             ],
         ];

--- a/tests/Rule/NoBracketsInMethodDirectiveTest.php
+++ b/tests/Rule/NoBracketsInMethodDirectiveTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoBracketsInMethodDirective;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoBracketsInMethodDirectiveTest extends \App\Tests\UnitTestCase
 {
@@ -23,26 +26,31 @@ final class NoBracketsInMethodDirectiveTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoBracketsInMethodDirective())->check($sample->lines(), $sample->lineNumber())
+            (new NoBracketsInMethodDirective())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            'Please remove "()" inside :method: directive',
+            Violation::from(
+                'Please remove "()" inside :method: directive',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample(':method:`Symfony\\Component\\OptionsResolver\\Options::offsetGet()`'),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample(':method:`Symfony\\Component\\OptionsResolver\\Options::offsetGet`'),
         ];
     }

--- a/tests/Rule/NoComposerReqTest.php
+++ b/tests/Rule/NoComposerReqTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoComposerReq;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoComposerReqTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class NoComposerReqTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoComposerReq())->check($sample->lines(), $sample->lineNumber())
+            (new NoComposerReq())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,11 +38,16 @@ final class NoComposerReqTest extends \App\Tests\UnitTestCase
     {
         return [
             [
-                'Please "composer require" instead of "composer req"',
+                Violation::from(
+                    'Please "composer require" instead of "composer req"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('composer req symfony/form'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('composer require symfony/form'),
             ],
         ];

--- a/tests/Rule/NoContractionTest.php
+++ b/tests/Rule/NoContractionTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoContraction;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoContractionTest extends \App\Tests\UnitTestCase
 {
@@ -23,7 +26,7 @@ final class NoContractionTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
         $configuredRules = [];
         foreach (NoContraction::getList() as $search => $message) {
@@ -32,22 +35,22 @@ final class NoContractionTest extends \App\Tests\UnitTestCase
 
         $violations = [];
         foreach ($configuredRules as $rule) {
-            $violation = $rule->check($sample->lines(), $sample->lineNumber());
-            if (null !== $violation) {
+            $violation = $rule->check($sample->lines(), $sample->lineNumber(), 'filename');
+            if (!$violation->isNull()) {
                 $violations[] = $violation;
             }
         }
 
-        if (null === $expected) {
+        if ($expected->isNull()) {
             static::assertCount(0, $violations);
         } else {
             static::assertCount(1, $violations);
-            static::assertSame($expected, $violations[0]);
+            static::assertEquals($expected, $violations[0]);
         }
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
@@ -109,10 +112,10 @@ final class NoContractionTest extends \App\Tests\UnitTestCase
         ];
 
         foreach ($valids as $valid) {
-            yield $valid => [null, new RstSample($valid)];
+            yield $valid => [NullViolation::create(), new RstSample($valid)];
 
             $validUppercase = ucfirst($valid);
-            yield $validUppercase => [null, new RstSample($validUppercase)];
+            yield $validUppercase => [NullViolation::create(), new RstSample($validUppercase)];
         }
 
         $invalids = [
@@ -169,7 +172,12 @@ final class NoContractionTest extends \App\Tests\UnitTestCase
 
         foreach ($invalids as $invalid => $matched) {
             yield $invalid => [
-                sprintf('Please do not use contraction for: %s', $matched ?? $invalid),
+                Violation::from(
+                    sprintf('Please do not use contraction for: %s', $matched ?? $invalid),
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample($invalid),
             ];
 
@@ -177,7 +185,12 @@ final class NoContractionTest extends \App\Tests\UnitTestCase
 
             if ($invalidUppercase !== $invalid) {
                 yield $invalidUppercase => [
+                Violation::from(
                     sprintf('Please do not use contraction for: %s', $matched ?? $invalidUppercase),
+                    'filename',
+                    1,
+                    ''
+                ),
                     new RstSample($invalidUppercase),
                 ];
             }

--- a/tests/Rule/NoDirectiveAfterShorthandTest.php
+++ b/tests/Rule/NoDirectiveAfterShorthandTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoDirectiveAfterShorthand;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoDirectiveAfterShorthandTest extends \App\Tests\UnitTestCase
 {
@@ -24,16 +27,16 @@ final class NoDirectiveAfterShorthandTest extends \App\Tests\UnitTestCase
      * @dataProvider validProvider
      * @dataProvider invalidProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoDirectiveAfterShorthand())->check($sample->lines(), $sample->lineNumber())
+            (new NoDirectiveAfterShorthand())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<string, array{0: null, 1: RstSample}>
+     * @return \Generator<string, array{0: ViolationInterface, 1: RstSample}>
      */
     public function validProvider(): \Generator
     {
@@ -58,23 +61,23 @@ RST;
 RST;
 
         yield 'valid' => [
-            null,
+            NullViolation::create(),
             new RstSample(''),
         ];
 
         yield 'valid 2' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid2),
         ];
 
         yield 'valid 3' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid3),
         ];
     }
 
     /**
-     * @return \Generator<array{0: string, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function invalidProvider(): \Generator
     {
@@ -91,12 +94,22 @@ RST;
 RST;
 
         yield [
-            'A ".. configuration-block::" directive is following a shorthand notation "::", this will lead to a broken markup!',
+            Violation::from(
+                'A ".. configuration-block::" directive is following a shorthand notation "::", this will lead to a broken markup!',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample($invalid),
         ];
 
         yield [
-            'A ".. configuration-block::" directive is following a shorthand notation "::", this will lead to a broken markup!',
+            Violation::from(
+                'A ".. configuration-block::" directive is following a shorthand notation "::", this will lead to a broken markup!',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample($invalid2),
         ];
     }

--- a/tests/Rule/NoExplicitUseOfCodeBlockPhpTest.php
+++ b/tests/Rule/NoExplicitUseOfCodeBlockPhpTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoExplicitUseOfCodeBlockPhp;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoExplicitUseOfCodeBlockPhpTest extends \App\Tests\UnitTestCase
 {
@@ -24,40 +27,55 @@ final class NoExplicitUseOfCodeBlockPhpTest extends \App\Tests\UnitTestCase
      * @dataProvider checkProvider
      * @dataProvider realSymfonyFileProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoExplicitUseOfCodeBlockPhp())->check($sample->lines(), $sample->lineNumber())
+            (new NoExplicitUseOfCodeBlockPhp())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('Check the following controller syntax::'),
         ];
 
         yield [
-            'Please do not use ".. code-block:: php", use "::" instead.',
+            Violation::from(
+                'Please do not use ".. code-block:: php", use "::" instead.',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample('.. code-block:: php'),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('.. code-block:: html+php'),
         ];
         yield [
-            'Please do not use ".. code-block:: php", use "::" instead.',
+            Violation::from(
+                'Please do not use ".. code-block:: php", use "::" instead.',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample('    .. code-block:: php'),
         ];
 
         yield [
-            'Please do not use ".. code-block:: php", use "::" instead.',
+            Violation::from(
+                'Please do not use ".. code-block:: php", use "::" instead.',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 'Welcome to our tutorial!',
                 '',
@@ -68,7 +86,7 @@ final class NoExplicitUseOfCodeBlockPhpTest extends \App\Tests\UnitTestCase
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '.. configuration-block::',
                 '',
@@ -78,7 +96,7 @@ final class NoExplicitUseOfCodeBlockPhpTest extends \App\Tests\UnitTestCase
             ], 2),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 '    .. configuration-block::',
                 '',
@@ -92,7 +110,7 @@ final class NoExplicitUseOfCodeBlockPhpTest extends \App\Tests\UnitTestCase
             ], 6),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample([
                 'Welcome to our tutorial!',
                 '',
@@ -105,7 +123,7 @@ final class NoExplicitUseOfCodeBlockPhpTest extends \App\Tests\UnitTestCase
     }
 
     /**
-     * @return \Generator<int|string, array{0: string|null, 1: RstSample}>
+     * @return \Generator<int|string, array{0: ViolationInterface, 1: RstSample}>
      */
     public function realSymfonyFileProvider(): \Generator
     {
@@ -452,76 +470,86 @@ placeholders.
 RST;
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample($content, 26),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample($content_with_blank_line_at_the_beginning, 27),
         ];
 
         yield [
-            'Please do not use ".. code-block:: php", use "::" instead.',
+            Violation::from(
+                'Please do not use ".. code-block:: php", use "::" instead.',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample($invalid_content, 14),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample($valid_code_block_after_headline, 3),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample($valid_two_following_php_code_blocks, 15),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample($valid_two_following_php_code_blocks_after_headline, 2),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample($valid_two_following_php_code_blocks_after_headline, 13),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample($valid_two_following_php_code_blocks_in_configuration_block, 5),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample($valid_two_following_php_code_blocks_in_configuration_block, 15),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample($valid_valid_in_code_block_text, 21),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample($valid_valid_in_code_block_rst, 21),
         ];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample($valid_follows_code_block, 11),
         ];
 
         yield 'valid_code_block_after_table' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid_code_block_after_table, 11),
         ];
 
         yield [
-            'Please do not use ".. code-block:: php", use "::" instead.',
+            Violation::from(
+                'Please do not use ".. code-block:: php", use "::" instead.',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample($invalid_content2, 18),
         ];
 
         yield 'valid because previous paragraph ends with question mark (?)' => [
-            null,
+            NullViolation::create(),
             new RstSample(<<<RST
 This is nice PHP code, isn't it?
 
@@ -533,7 +561,7 @@ RST
         ];
 
         yield 'php code block following a configuration-block' => [
-            null,
+            NullViolation::create(),
             new RstSample(<<<RST
 .. configuration-block::
 
@@ -549,7 +577,7 @@ RST
         ];
 
         yield 'php code block following a terminal block' => [
-            null,
+            NullViolation::create(),
             new RstSample(<<<'RST'
 .. code-block:: terminal
 
@@ -564,7 +592,7 @@ RST
         ];
 
         yield 'php code block unsing an option' => [
-            null,
+            NullViolation::create(),
             new RstSample(<<<RST
 .. code-block:: php
    :lineos:
@@ -579,7 +607,7 @@ RST
                 'php code block following %s',
                 $previousDirective
             ) => [
-                null,
+                NullViolation::create(),
                 new RstSample(sprintf(<<<RST
 %s
 

--- a/tests/Rule/NoInheritdocInCodeExamplesTest.php
+++ b/tests/Rule/NoInheritdocInCodeExamplesTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoInheritdocInCodeExamples;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoInheritdocInCodeExamplesTest extends \App\Tests\UnitTestCase
 {
@@ -23,29 +26,34 @@ final class NoInheritdocInCodeExamplesTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoInheritdocInCodeExamples())->check($sample->lines(), $sample->lineNumber())
+            (new NoInheritdocInCodeExamples())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     public function checkProvider(): \Generator
     {
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('* {@inheritdoc}'),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('fine'),
         ];
 
         foreach (self::phpCodeBlocks() as $codeBlock) {
             yield [
-                'Please do not use "@inheritdoc"',
+                Violation::from(
+                    'Please do not use "@inheritdoc"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '',

--- a/tests/Rule/NoNamespaceAfterUseStatementsTest.php
+++ b/tests/Rule/NoNamespaceAfterUseStatementsTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoNamespaceAfterUseStatements;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoNamespaceAfterUseStatementsTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class NoNamespaceAfterUseStatementsTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoNamespaceAfterUseStatements())->check($sample->lines(), $sample->lineNumber())
+            (new NoNamespaceAfterUseStatements())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -39,7 +42,7 @@ final class NoNamespaceAfterUseStatementsTest extends \App\Tests\UnitTestCase
         foreach ($codeBlocks as $codeBlock) {
             // WITH blank line after directive
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -50,7 +53,7 @@ final class NoNamespaceAfterUseStatementsTest extends \App\Tests\UnitTestCase
 
             // WITHOUT blank line after directive
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     $codeBlock,
                     '    namespace App;',
@@ -63,7 +66,12 @@ final class NoNamespaceAfterUseStatementsTest extends \App\Tests\UnitTestCase
         foreach ($codeBlocks as $codeBlock) {
             // WITH blank line after directive
             yield [
-                'Please move the namespace before the use statement(s)',
+                Violation::from(
+                    'Please move the namespace before the use statement(s)',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -74,7 +82,12 @@ final class NoNamespaceAfterUseStatementsTest extends \App\Tests\UnitTestCase
 
             // WITHOUT blank line after directive
             yield [
-                'Please move the namespace before the use statement(s)',
+                Violation::from(
+                    'Please move the namespace before the use statement(s)',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '    use Symfony\A;',

--- a/tests/Rule/NoPhpPrefixBeforeBinConsoleTest.php
+++ b/tests/Rule/NoPhpPrefixBeforeBinConsoleTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoPhpPrefixBeforeBinConsole;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoPhpPrefixBeforeBinConsoleTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class NoPhpPrefixBeforeBinConsoleTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoPhpPrefixBeforeBinConsole())->check($sample->lines(), $sample->lineNumber())
+            (new NoPhpPrefixBeforeBinConsole())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,11 +38,16 @@ final class NoPhpPrefixBeforeBinConsoleTest extends \App\Tests\UnitTestCase
     {
         return [
             [
-                'Please remove "php" prefix before "bin/console"',
+                Violation::from(
+                    'Please remove "php" prefix before "bin/console"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('please execute php bin/console foo'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('please execute bin/console foo'),
             ],
         ];

--- a/tests/Rule/NoPhpPrefixBeforeComposerTest.php
+++ b/tests/Rule/NoPhpPrefixBeforeComposerTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoPhpPrefixBeforeComposer;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoPhpPrefixBeforeComposerTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class NoPhpPrefixBeforeComposerTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoPhpPrefixBeforeComposer())->check($sample->lines(), $sample->lineNumber())
+            (new NoPhpPrefixBeforeComposer())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,11 +38,16 @@ final class NoPhpPrefixBeforeComposerTest extends \App\Tests\UnitTestCase
     {
         return [
             [
-                'Please remove "php" prefix',
+                Violation::from(
+                    'Please remove "php" prefix',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('please execute php composer'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('please execute composer install'),
             ],
         ];

--- a/tests/Rule/NoSpaceBeforeSelfXmlClosingTagTest.php
+++ b/tests/Rule/NoSpaceBeforeSelfXmlClosingTagTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\NoSpaceBeforeSelfXmlClosingTag;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class NoSpaceBeforeSelfXmlClosingTagTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class NoSpaceBeforeSelfXmlClosingTagTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new NoSpaceBeforeSelfXmlClosingTag())->check($sample->lines(), $sample->lineNumber())
+            (new NoSpaceBeforeSelfXmlClosingTag())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,23 +38,33 @@ final class NoSpaceBeforeSelfXmlClosingTagTest extends \App\Tests\UnitTestCase
     {
         return [
             [
-                'Please remove space before "/>"',
+                Violation::from(
+                    'Please remove space before "/>"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('<argument type="service" id="sonata.admin.search.handler" />'),
             ],
             [
-                'Please remove space before "/>"',
+                Violation::from(
+                    'Please remove space before "/>"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('<argument />'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('/>'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('<argument type="service" id="sonata.admin.search.handler"/>'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('<br/>'),
             ],
         ];

--- a/tests/Rule/OnlyBackslashesInNamespaceInPhpCodeBlockTest.php
+++ b/tests/Rule/OnlyBackslashesInNamespaceInPhpCodeBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\OnlyBackslashesInNamespaceInPhpCodeBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class OnlyBackslashesInNamespaceInPhpCodeBlockTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class OnlyBackslashesInNamespaceInPhpCodeBlockTest extends \App\Tests\Unit
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new OnlyBackslashesInNamespaceInPhpCodeBlock())->check($sample->lines(), $sample->lineNumber())
+            (new OnlyBackslashesInNamespaceInPhpCodeBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,7 +38,12 @@ final class OnlyBackslashesInNamespaceInPhpCodeBlockTest extends \App\Tests\Unit
     {
         foreach (self::phpCodeBlocks() as $codeBlock) {
             yield [
-                'Please check "namespace App/Handler;", it should not contain "/"',
+                Violation::from(
+                    'Please check "namespace App/Handler;", it should not contain "/"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -46,7 +54,12 @@ final class OnlyBackslashesInNamespaceInPhpCodeBlockTest extends \App\Tests\Unit
             ];
 
             yield [
-                'Please check "NaMeSpaCe App/Handler;", it should not contain "/"',
+                Violation::from(
+                    'Please check "NaMeSpaCe App/Handler;", it should not contain "/"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -58,7 +71,12 @@ final class OnlyBackslashesInNamespaceInPhpCodeBlockTest extends \App\Tests\Unit
         }
 
         yield [
-            'Please check "namespace App/Handler;", it should not contain "/"',
+            Violation::from(
+                'Please check "namespace App/Handler;", it should not contain "/"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '::',
                 '',
@@ -69,7 +87,7 @@ final class OnlyBackslashesInNamespaceInPhpCodeBlockTest extends \App\Tests\Unit
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
     }

--- a/tests/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlockTest.php
+++ b/tests/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlockTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\OnlyBackslashesInUseStatementsInPhpCodeBlock;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class OnlyBackslashesInUseStatementsInPhpCodeBlockTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class OnlyBackslashesInUseStatementsInPhpCodeBlockTest extends \App\Tests\
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new OnlyBackslashesInUseStatementsInPhpCodeBlock())->check($sample->lines(), $sample->lineNumber())
+            (new OnlyBackslashesInUseStatementsInPhpCodeBlock())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -35,7 +38,12 @@ final class OnlyBackslashesInUseStatementsInPhpCodeBlockTest extends \App\Tests\
     {
         foreach (self::phpCodeBlocks() as $codeBlock) {
             yield [
-                'Please check "use App/Handler;", it should not contain "/"',
+                Violation::from(
+                    'Please check "use App/Handler;", it should not contain "/"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -46,7 +54,12 @@ final class OnlyBackslashesInUseStatementsInPhpCodeBlockTest extends \App\Tests\
             ];
 
             yield [
-                'Please check "UsE App/Handler;", it should not contain "/"',
+                Violation::from(
+                    'Please check "UsE App/Handler;", it should not contain "/"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -58,7 +71,12 @@ final class OnlyBackslashesInUseStatementsInPhpCodeBlockTest extends \App\Tests\
         }
 
         yield [
-            'Please check "use App/Handler;", it should not contain "/"',
+            Violation::from(
+                'Please check "use App/Handler;", it should not contain "/"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample([
                 '::',
                 '',
@@ -69,7 +87,7 @@ final class OnlyBackslashesInUseStatementsInPhpCodeBlockTest extends \App\Tests\
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('temp'),
         ];
     }

--- a/tests/Rule/OrderedUseStatementsTest.php
+++ b/tests/Rule/OrderedUseStatementsTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\OrderedUseStatements;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class OrderedUseStatementsTest extends \App\Tests\UnitTestCase
 {
@@ -23,11 +26,11 @@ final class OrderedUseStatementsTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new OrderedUseStatements())->check($sample->lines(), $sample->lineNumber())
+            (new OrderedUseStatements())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
@@ -39,7 +42,7 @@ final class OrderedUseStatementsTest extends \App\Tests\UnitTestCase
         foreach ($codeBlocks as $codeBlock) {
             // WITH blank line after directive
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -50,7 +53,7 @@ final class OrderedUseStatementsTest extends \App\Tests\UnitTestCase
 
             // WITHOUT blank line after directive
             yield [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     $codeBlock,
                     '    use Symfony\A;',
@@ -63,7 +66,12 @@ final class OrderedUseStatementsTest extends \App\Tests\UnitTestCase
         foreach ($codeBlocks as $codeBlock) {
             // WITH blank line after directive
             yield [
-                'Please reorder the use statements alphabetically',
+                Violation::from(
+                    'Please reorder the use statements alphabetically',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '',
@@ -74,7 +82,12 @@ final class OrderedUseStatementsTest extends \App\Tests\UnitTestCase
 
             // WITHOUT blank line after directive
             yield [
-                'Please reorder the use statements alphabetically',
+                Violation::from(
+                    'Please reorder the use statements alphabetically',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     $codeBlock,
                     '    use Symfony\B;',
@@ -255,35 +268,35 @@ and compose your services with them::
 RST;
 
         yield 'valid with trait' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid_with_trait, 1),
         ];
         yield 'valid with 2 code examples in one block' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid_with_two_code_examples_in_one_block),
         ];
         yield 'valid with nsort' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid_with_nsort),
         ];
         yield 'valid with use statement in comment' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid_with_use_statement_in_comment),
         ];
         yield 'valid without class but variable in between' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid_without_class_but_variable_in_between, 2),
         ];
         yield 'valid with uppercase' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid_with_uppercase),
         ];
         yield 'valid 2' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid2),
         ];
         yield 'valid in trait definition' => [
-            null,
+            NullViolation::create(),
             new RstSample($valid_in_trait_definition, 1),
         ];
     }

--- a/tests/Rule/PhpPrefixBeforeBinConsoleTest.php
+++ b/tests/Rule/PhpPrefixBeforeBinConsoleTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\PhpPrefixBeforeBinConsole;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class PhpPrefixBeforeBinConsoleTest extends \App\Tests\UnitTestCase
 {
@@ -23,22 +26,30 @@ final class PhpPrefixBeforeBinConsoleTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new PhpPrefixBeforeBinConsole())->check($sample->lines(), $sample->lineNumber())
+            (new PhpPrefixBeforeBinConsole())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     public function checkProvider(): \Generator
     {
-        yield [null, new RstSample('please execute php bin/console foo')];
-        yield [null, new RstSample('you can use `bin/console` to execute')];
-        yield [null, new RstSample('php "%s/../bin/console"')];
-        yield [null, new RstSample('.. _`copying Symfony\'s bin/console source`: https://github.com/symfony/recipes/blob/master/symfony/console/3.3/bin/console')];
-        yield [null, new RstSample('├─ bin/console')];
-        yield [null, new RstSample('Symfony\Component\Console\Application->run() at /home/greg/demo/bin/console:42')];
-        yield ['Please add "php" prefix before "bin/console"', new RstSample('please execute bin/console foo')];
+        yield [NullViolation::create(), new RstSample('please execute php bin/console foo')];
+        yield [NullViolation::create(), new RstSample('you can use `bin/console` to execute')];
+        yield [NullViolation::create(), new RstSample('php "%s/../bin/console"')];
+        yield [NullViolation::create(), new RstSample('.. _`copying Symfony\'s bin/console source`: https://github.com/symfony/recipes/blob/master/symfony/console/3.3/bin/console')];
+        yield [NullViolation::create(), new RstSample('├─ bin/console')];
+        yield [NullViolation::create(), new RstSample('Symfony\Component\Console\Application->run() at /home/greg/demo/bin/console:42')];
+        yield [
+            Violation::from(
+                'Please add "php" prefix before "bin/console"',
+                'filename',
+                1,
+                ''
+            ),
+            new RstSample('please execute bin/console foo'),
+        ];
     }
 }

--- a/tests/Rule/ShortArraySyntaxTest.php
+++ b/tests/Rule/ShortArraySyntaxTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\ShortArraySyntax;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class ShortArraySyntaxTest extends \App\Tests\UnitTestCase
 {
@@ -23,62 +26,82 @@ final class ShortArraySyntaxTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new ShortArraySyntax())->check($sample->lines(), $sample->lineNumber())
+            (new ShortArraySyntax())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return array<array{0: string|null, 1: RstSample}>
+     * @return array<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): array
     {
         return [
             [
-                'Please use short array syntax',
+                Violation::from(
+                    'Please use short array syntax',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('->add(\'foo\', null, array(\'key\' => 1));'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('->add(\'foo\', null, [\'key\' => 1[);'),
             ],
             [
-                'Please use short array syntax',
+                Violation::from(
+                    'Please use short array syntax',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('if (in_array(1, array())) { '),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('if (in_array(1, [])) {'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('$forms = iterator_to_array($forms);'),
             ],
             [
-                'Please use short array syntax',
+                Violation::from(
+                    'Please use short array syntax',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample("->add('tags', null, array('label' => 'les tags'), null, array('expanded' => true, 'multiple' => true));"),
             ],
             [
-                'Please use short array syntax',
+                Violation::from(
+                    'Please use short array syntax',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('->assertLength(array(\'max\' => 100))'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('array(3) {'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample(' array(3) {'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('      array(3) {'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('array(999) {      '),
             ],
         ];

--- a/tests/Rule/SpaceBeforeSelfXmlClosingTagTest.php
+++ b/tests/Rule/SpaceBeforeSelfXmlClosingTagTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\SpaceBeforeSelfXmlClosingTag;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class SpaceBeforeSelfXmlClosingTagTest extends \App\Tests\UnitTestCase
 {
@@ -23,42 +26,52 @@ final class SpaceBeforeSelfXmlClosingTagTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new SpaceBeforeSelfXmlClosingTag())->check($sample->lines(), $sample->lineNumber())
+            (new SpaceBeforeSelfXmlClosingTag())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return array<array{0: string|null, 1: RstSample}>
+     * @return array<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): array
     {
         return [
             [
-                'Please add space before "/>"',
+                Violation::from(
+                    'Please add space before "/>"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('<argument type="service" id="sonata.admin.search.handler"/>'),
             ],
             [
-                'Please add space before "/>"',
+                Violation::from(
+                    'Please add space before "/>"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('<argument/>'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample(' />'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('<argument type="service" id="sonata.admin.search.handler" />'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('<br />'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('`Twig docs <https://twig.symfony.com/doc/2.x/>`_;'),
             ],
         ];

--- a/tests/Rule/SpaceBetweenLabelAndLinkInDocTest.php
+++ b/tests/Rule/SpaceBetweenLabelAndLinkInDocTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\SpaceBetweenLabelAndLinkInDoc;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class SpaceBetweenLabelAndLinkInDocTest extends \App\Tests\UnitTestCase
 {
@@ -23,26 +26,31 @@ final class SpaceBetweenLabelAndLinkInDocTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new SpaceBetweenLabelAndLinkInDoc())->check($sample->lines(), $sample->lineNumber())
+            (new SpaceBetweenLabelAndLinkInDoc())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            'Please add a space between "File" and "</reference/constraints/File>" inside :doc: directive',
+            Violation::from(
+                'Please add a space between "File" and "</reference/constraints/File>" inside :doc: directive',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample(':doc:`File</reference/constraints/File>`'),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample(':doc:`File </reference/constraints/File>`'),
         ];
     }

--- a/tests/Rule/SpaceBetweenLabelAndLinkInRefTest.php
+++ b/tests/Rule/SpaceBetweenLabelAndLinkInRefTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\SpaceBetweenLabelAndLinkInRef;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class SpaceBetweenLabelAndLinkInRefTest extends \App\Tests\UnitTestCase
 {
@@ -23,26 +26,31 @@ final class SpaceBetweenLabelAndLinkInRefTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new SpaceBetweenLabelAndLinkInRef())->check($sample->lines(), $sample->lineNumber())
+            (new SpaceBetweenLabelAndLinkInRef())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            'Please add a space between "receiving them via a worker" and "<messenger-worker>" inside :ref: directive',
+            Violation::from(
+                'Please add a space between "receiving them via a worker" and "<messenger-worker>" inside :ref: directive',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample(':ref:`receiving them via a worker<messenger-worker>`'),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample(':ref:`receiving them via a worker <messenger-worker>`'),
         ];
     }

--- a/tests/Rule/UnusedLinksTest.php
+++ b/tests/Rule/UnusedLinksTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\UnusedLinks;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class UnusedLinksTest extends \App\Tests\UnitTestCase
 {
@@ -24,23 +27,23 @@ final class UnusedLinksTest extends \App\Tests\UnitTestCase
      * @dataProvider validProvider
      * @dataProvider invalidProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new UnusedLinks())->check($sample->lines())
+            (new UnusedLinks())->check($sample->lines(), 'filename')
         );
     }
 
     public function validProvider(): \Generator
     {
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('this is a test'),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample(<<<RST
 I am a `Link`_
 
@@ -50,7 +53,7 @@ RST
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample(<<<RST
 I am a `Link`_ and `Link2`_
 
@@ -61,7 +64,7 @@ RST
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample(<<<RST
 I am a `Link`_
 
@@ -71,7 +74,7 @@ RST
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample(<<<RST
 I am a `Link`_ and `Link2`_
 
@@ -82,7 +85,7 @@ RST
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample(<<<RST
 I am `a Link`_, `some other Link`_ and Link2_
 
@@ -94,7 +97,7 @@ RST
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample(<<<RST
 Date Handling
 ~~~~~~~~~~~~~
@@ -109,7 +112,7 @@ RST
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample(<<<RST
 Active Core Members
 ~~~~~~~~~~~~~~~~~~~
@@ -196,7 +199,12 @@ RST
     public function invalidProvider(): \Generator
     {
         yield [
-            'The following link definitions aren\'t used anymore and should be removed: "unused"',
+            Violation::from(
+                'The following link definitions aren\'t used anymore and should be removed: "unused"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample(<<<RST
 I am a `Link`_
 
@@ -207,7 +215,12 @@ RST
         ];
 
         yield [
-            'The following link definitions aren\'t used anymore and should be removed: "unused"',
+            Violation::from(
+                'The following link definitions aren\'t used anymore and should be removed: "unused"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample(<<<RST
 I am a `Link`_
 
@@ -218,7 +231,12 @@ RST
         ];
 
         yield [
-            'The following link definitions aren\'t used anymore and should be removed: "unused2", "unused1", "unused 3"',
+            Violation::from(
+                'The following link definitions aren\'t used anymore and should be removed: "unused2", "unused1", "unused 3"',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample(<<<RST
 I am a `Link`_
 

--- a/tests/Rule/UseDeprecatedDirectiveInsteadOfVersionaddedTest.php
+++ b/tests/Rule/UseDeprecatedDirectiveInsteadOfVersionaddedTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\UseDeprecatedDirectiveInsteadOfVersionadded;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class UseDeprecatedDirectiveInsteadOfVersionaddedTest extends \App\Tests\UnitTestCase
 {
@@ -24,22 +27,22 @@ final class UseDeprecatedDirectiveInsteadOfVersionaddedTest extends \App\Tests\U
      * @dataProvider validProvider
      * @dataProvider invalidProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new UseDeprecatedDirectiveInsteadOfVersionadded())->check($sample->lines(), $sample->lineNumber())
+            (new UseDeprecatedDirectiveInsteadOfVersionadded())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return array<int|string, array{0: null, 1: RstSample}>
+     * @return array<int|string, array{0: ViolationInterface, 1: RstSample}>
      */
     public function validProvider(): array
     {
         return [
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. versionadded:: 3.4',
                     '',
@@ -47,14 +50,14 @@ final class UseDeprecatedDirectiveInsteadOfVersionaddedTest extends \App\Tests\U
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. versionadded:: 3.4',
                     '    Foo was added in Symfony 3.4.',
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. deprecated:: 3.4',
                     '',
@@ -62,14 +65,14 @@ final class UseDeprecatedDirectiveInsteadOfVersionaddedTest extends \App\Tests\U
                 ]),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. deprecated:: 3.4',
                     '    Foo was deprecated in Symfony 3.4.',
                 ]),
             ],
             'versionadded directive with deprecated option' => [
-                null,
+                NullViolation::create(),
                 new RstSample([
                     '.. versionadded:: 4.3',
                     '    The ``deprecated`` option for service aliases was introduced in Symfony 4.3.',
@@ -79,13 +82,18 @@ final class UseDeprecatedDirectiveInsteadOfVersionaddedTest extends \App\Tests\U
     }
 
     /**
-     * @return array<array{0: string, 1: RstSample}>
+     * @return array<array{0: ViolationInterface, 1: RstSample}>
      */
     public function invalidProvider(): array
     {
         return [
             [
-                'Please use ".. deprecated::" instead of ".. versionadded::"',
+                Violation::from(
+                    'Please use ".. deprecated::" instead of ".. versionadded::"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. versionadded:: 3.4',
                     '',
@@ -93,7 +101,12 @@ final class UseDeprecatedDirectiveInsteadOfVersionaddedTest extends \App\Tests\U
                 ]),
             ],
             [
-                'Please use ".. deprecated::" instead of ".. versionadded::"',
+                Violation::from(
+                    'Please use ".. deprecated::" instead of ".. versionadded::"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample([
                     '.. versionadded:: 3.4',
                     '    Foo was deprecated in Symfony 3.4.',

--- a/tests/Rule/UseHttpsXsdUrlsTest.php
+++ b/tests/Rule/UseHttpsXsdUrlsTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\UseHttpsXsdUrls;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class UseHttpsXsdUrlsTest extends \App\Tests\UnitTestCase
 {
@@ -23,23 +26,28 @@ final class UseHttpsXsdUrlsTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new UseHttpsXsdUrls())->check($sample->lines(), $sample->lineNumber())
+            (new UseHttpsXsdUrls())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     public function checkProvider(): \Generator
     {
-        yield [null, new RstSample('')];
+        yield [NullViolation::create(), new RstSample('')];
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('https://symfony.com/schema/dic/services/services-1.0.xsd'),
         ];
         yield [
-            'Please use "https" for http://symfony.com/schema/dic/services/services-1.0.xsd',
+            Violation::from(
+                'Please use "https" for http://symfony.com/schema/dic/services/services-1.0.xsd',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample('http://symfony.com/schema/dic/services/services-1.0.xsd'),
         ];
     }

--- a/tests/Rule/ValidUseStatementsTests.php
+++ b/tests/Rule/ValidUseStatementsTests.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\ValidUseStatements;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class ValidUseStatementsTests extends \App\Tests\UnitTestCase
 {
@@ -23,30 +26,35 @@ final class ValidUseStatementsTests extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new ValidUseStatements())->check($sample->lines(), $sample->lineNumber())
+            (new ValidUseStatements())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return array<array{0: string|null, 1: RstSample}>
+     * @return array<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): array
     {
         return [
             [
-                'Please do not escape the backslashes in a use statement.',
+                Violation::from(
+                    'Please do not escape the backslashes in a use statement.',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('use Symfony\\\\Component\\\\Form\\\\Extension\\\\Core\\\\Type\\\\FormType;'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('use Symfony\Component\Form\Extension\Core\Type\FormType;'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('don\'t use the :class:`Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\ControllerTrait`'),
             ],
         ];

--- a/tests/Rule/VersionaddedDirectiveMinVersionTest.php
+++ b/tests/Rule/VersionaddedDirectiveMinVersionTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\VersionaddedDirectiveMinVersion;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class VersionaddedDirectiveMinVersionTest extends \App\Tests\UnitTestCase
 {
@@ -23,37 +26,42 @@ final class VersionaddedDirectiveMinVersionTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, string $minVersion, RstSample $sample): void
+    public function check(ViolationInterface $expected, string $minVersion, RstSample $sample): void
     {
         $rule = new VersionaddedDirectiveMinVersion();
         $rule->setOptions([
             'min_version' => $minVersion,
         ]);
 
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            $rule->check($sample->lines(), $sample->lineNumber())
+            $rule->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return array<array{0: string|null, 1: string, 2: RstSample}>
+     * @return array<array{0: ViolationInterface, 1: string, 2: RstSample}>
      */
     public function checkProvider(): array
     {
         return [
             [
-                null,
+                NullViolation::create(),
                 '3.4',
                 new RstSample('.. versionadded:: 3.4'),
             ],
             [
-                null,
+                NullViolation::create(),
                 '3.4',
                 new RstSample('.. versionadded:: 4.2'),
             ],
             [
-                'Please only provide ".. versionadded::" if the version is greater/equal "3.4"',
+                Violation::from(
+                    'Please only provide ".. versionadded::" if the version is greater/equal "3.4"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 '3.4',
                 new RstSample('.. versionadded:: 2.8'),
             ],

--- a/tests/Rule/VersionaddedDirectiveShouldHaveVersionTest.php
+++ b/tests/Rule/VersionaddedDirectiveShouldHaveVersionTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\VersionaddedDirectiveShouldHaveVersion;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 use Composer\Semver\VersionParser;
 
 final class VersionaddedDirectiveShouldHaveVersionTest extends \App\Tests\UnitTestCase
@@ -24,43 +27,53 @@ final class VersionaddedDirectiveShouldHaveVersionTest extends \App\Tests\UnitTe
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
             (new VersionaddedDirectiveShouldHaveVersion(new VersionParser()))
-                ->check($sample->lines(), $sample->lineNumber())
+                ->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return array<array{0: string|null, 1: RstSample}>
+     * @return array<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): array
     {
         return [
             [
-                null,
+                NullViolation::create(),
                 new RstSample('.. versionadded:: 1'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('.. versionadded:: 1.2'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('.. versionadded:: 1.2.0'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('.. versionadded:: 1.2   '),
             ],
             [
-                'Please provide a version behind ".. versionadded::"',
+                Violation::from(
+                    'Please provide a version behind ".. versionadded::"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('.. versionadded::'),
             ],
             [
-                'Please provide a numeric version behind ".. versionadded::" instead of "foo"',
+                Violation::from(
+                    'Please provide a numeric version behind ".. versionadded::" instead of "foo"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('.. versionadded:: foo'),
             ],
         ];

--- a/tests/Rule/YamlInsteadOfYmlSuffixTest.php
+++ b/tests/Rule/YamlInsteadOfYmlSuffixTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\YamlInsteadOfYmlSuffix;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class YamlInsteadOfYmlSuffixTest extends \App\Tests\UnitTestCase
 {
@@ -23,38 +26,48 @@ final class YamlInsteadOfYmlSuffixTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new YamlInsteadOfYmlSuffix())->check($sample->lines(), $sample->lineNumber())
+            (new YamlInsteadOfYmlSuffix())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return array<array{0: string|null, 1: RstSample}>
+     * @return array<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): array
     {
         return [
             [
-                'Please use ".. code-block:: yaml" instead of ".. code-block:: yml"',
+                Violation::from(
+                    'Please use ".. code-block:: yaml" instead of ".. code-block:: yml"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('.. code-block:: yml'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('.. code-block:: yaml'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('.travis.yml'),
             ],
             [
-                'Please use ".yaml" instead of ".yml"',
+                Violation::from(
+                    'Please use ".yaml" instead of ".yml"',
+                    'filename',
+                    1,
+                    ''
+                ),
                 new RstSample('Register your service in services.yml file'),
             ],
             [
-                null,
+                NullViolation::create(),
                 new RstSample('Register your service in services.yaml file'),
             ],
         ];

--- a/tests/Rule/YarnDevOptionAtTheEndTest.php
+++ b/tests/Rule/YarnDevOptionAtTheEndTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\YarnDevOptionAtTheEnd;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class YarnDevOptionAtTheEndTest extends \App\Tests\UnitTestCase
 {
@@ -23,26 +26,31 @@ final class YarnDevOptionAtTheEndTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new YarnDevOptionAtTheEnd())->check($sample->lines(), $sample->lineNumber())
+            (new YarnDevOptionAtTheEnd())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            'Please move "--dev" option to the end of the command',
+            Violation::from(
+                'Please move "--dev" option to the end of the command',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample('yarn add --dev jquery'),
         ];
 
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('yarn add jquery --dev'),
         ];
     }

--- a/tests/Rule/YarnDevOptionNotAtTheEndTest.php
+++ b/tests/Rule/YarnDevOptionNotAtTheEndTest.php
@@ -15,6 +15,9 @@ namespace App\Tests\Rule;
 
 use App\Rule\YarnDevOptionNotAtTheEnd;
 use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
 
 final class YarnDevOptionNotAtTheEndTest extends \App\Tests\UnitTestCase
 {
@@ -23,26 +26,31 @@ final class YarnDevOptionNotAtTheEndTest extends \App\Tests\UnitTestCase
      *
      * @dataProvider checkProvider
      */
-    public function check(?string $expected, RstSample $sample): void
+    public function check(ViolationInterface $expected, RstSample $sample): void
     {
-        static::assertSame(
+        static::assertEquals(
             $expected,
-            (new YarnDevOptionNotAtTheEnd())->check($sample->lines(), $sample->lineNumber())
+            (new YarnDevOptionNotAtTheEnd())->check($sample->lines(), $sample->lineNumber(), 'filename')
         );
     }
 
     /**
-     * @return \Generator<array{0: string|null, 1: RstSample}>
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
      */
     public function checkProvider(): \Generator
     {
         yield [
-            null,
+            NullViolation::create(),
             new RstSample('yarn add --dev jquery'),
         ];
 
         yield [
-            'Please move "--dev" option before the package',
+            Violation::from(
+                'Please move "--dev" option before the package',
+                'filename',
+                1,
+                ''
+            ),
             new RstSample('yarn add jquery --dev'),
         ];
     }


### PR DESCRIPTION
This should fix #827 

I added an interface `ViolationInterface` with the NullObject pattern to avoid multiple return types.
I know that the PR is really big but I couldn't split it into many parts.