### PR TITLE
Fix regex and add new test for `UseNamedConstructorWithoutNewKeyword`

### DIFF
--- a/src/Rule/UseNamedConstructorWithoutNewKeywordRule.php
+++ b/src/Rule/UseNamedConstructorWithoutNewKeywordRule.php
@@ -40,7 +40,7 @@ final class UseNamedConstructorWithoutNewKeywordRule extends AbstractRule implem
             return NullViolation::create();
         }
 
-        if ([] === $line->raw()->match('/new .*::/')) {
+        if ([] === $line->raw()->match('/new [^(]*::/')) {
             return NullViolation::create();
         }
 

--- a/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
+++ b/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
@@ -37,6 +37,14 @@ final class UseNamedConstructorWithoutNewKeywordRuleTest extends UnitTestCase
 
     public static function checkProvider(): \Generator
     {
+        $validLines = [
+            '$client = new NoPrivateNetworkHttpClient(HttpClient::create());',
+            'return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);',
+            '$container->register(Ldap::class)->addArgument(new Reference(Adapter::class));',
+            'new Status(Status::YES);',
+            'return new Response(null, Response::HTTP_TOO_MANY_REQUESTS, $headers);',
+        ];
+
         foreach (self::phpCodeBlocks() as $codeBlock) {
             yield sprintf('Has violation for code-block "%s"', $codeBlock) => [
                 Violation::from(
@@ -51,45 +59,15 @@ final class UseNamedConstructorWithoutNewKeywordRuleTest extends UnitTestCase
                 ], 1),
             ];
 
-            yield sprintf('No violation for code-block "%s" - First case', $codeBlock) => [
-                NullViolation::create(),
-                new RstSample([
-                    $codeBlock,
-                    '    return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);'
-                ], 1),
-            ];
-
-            yield sprintf('No violation for code-block "%s" - Second case', $codeBlock) => [
-                NullViolation::create(),
-                new RstSample([
-                    $codeBlock,
-                    '    $client = new NoPrivateNetworkHttpClient(HttpClient::create());'
-                ], 1),
-            ];
-
-            yield sprintf('No violation for code-block "%s" - Third case', $codeBlock) => [
-                NullViolation::create(),
-                new RstSample([
-                    $codeBlock,
-                    '    $container->register(Ldap::class)->addArgument(new Reference(Adapter::class));'
-                ], 1),
-            ];
-
-            yield sprintf('No violation for code-block "%s" - Fourth case', $codeBlock) => [
-                NullViolation::create(),
-                new RstSample([
-                    $codeBlock,
-                    '    new Status(Status::YES);',
-                ], 1),
-            ];
-
-            yield sprintf('No violation for code-block "%s" - Fifth case', $codeBlock) => [
-                NullViolation::create(),
-                new RstSample([
-                    $codeBlock,
-                    '    return new Response(null, Response::HTTP_TOO_MANY_REQUESTS, $headers);',
-                ], 1),
-            ];
+            foreach ($validLines as $line) {
+                yield sprintf('NO violation for line "%s" in code-block "%s"', $line, $codeBlock) => [
+                    NullViolation::create(),
+                    new RstSample([
+                        $codeBlock,
+                        '    '.$line,
+                    ], 1),
+                ];
+            }
         }
     }
 }

--- a/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
+++ b/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
@@ -51,17 +51,44 @@ final class UseNamedConstructorWithoutNewKeywordRuleTest extends UnitTestCase
                 ], 1),
             ];
 
-            yield sprintf('No violation for code-block "%s"', $codeBlock) => [
+            yield sprintf('No violation for code-block "%s" - First case', $codeBlock) => [
                 NullViolation::create(),
                 new RstSample([
                     $codeBlock,
-                    '    $this->somePhp();',
-                    '    return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);',
-                    '    $client = new NoPrivateNetworkHttpClient(HttpClient::create());',
-                    '    $container->register(Ldap::class)->addArgument(new Reference(Adapter::class));',
+                    '    return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);'
+                ], 1),
+            ];
+
+            yield sprintf('No violation for code-block "%s" - Second case', $codeBlock) => [
+                NullViolation::create(),
+                new RstSample([
+                    $codeBlock,
+                    '    $client = new NoPrivateNetworkHttpClient(HttpClient::create());'
+                ], 1),
+            ];
+
+            yield sprintf('No violation for code-block "%s" - Third case', $codeBlock) => [
+                NullViolation::create(),
+                new RstSample([
+                    $codeBlock,
+                    '    $container->register(Ldap::class)->addArgument(new Reference(Adapter::class));'
+                ], 1),
+            ];
+
+            yield sprintf('No violation for code-block "%s" - Fourth case', $codeBlock) => [
+                NullViolation::create(),
+                new RstSample([
+                    $codeBlock,
                     '    new Status(Status::YES);',
+                ], 1),
+            ];
+
+            yield sprintf('No violation for code-block "%s" - Fifth case', $codeBlock) => [
+                NullViolation::create(),
+                new RstSample([
+                    $codeBlock,
                     '    return new Response(null, Response::HTTP_TOO_MANY_REQUESTS, $headers);',
-                ], 2),
+                ], 1),
             ];
         }
     }

--- a/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
+++ b/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
@@ -57,6 +57,10 @@ final class UseNamedConstructorWithoutNewKeywordRuleTest extends UnitTestCase
                     $codeBlock,
                     '    $this->somePhp();',
                     '    return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);',
+                    '    $client = new NoPrivateNetworkHttpClient(HttpClient::create());',
+                    '    $container->register(Ldap::class)->addArgument(new Reference(Adapter::class));',
+                    '    new Status(Status::YES);',
+                    '    $response = new Response('Hello '.$name, Response::HTTP_OK);',
                 ], 2),
             ];
         }

--- a/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
+++ b/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
@@ -56,15 +56,6 @@ final class UseNamedConstructorWithoutNewKeywordRuleTest extends UnitTestCase
                 new RstSample([
                     $codeBlock,
                     '    $this->somePhp();',
-                    '    new class();',
-                ], 2),
-            ];
-
-            yield sprintf('No violation for code-block "%s"', $codeBlock) => [
-                NullViolation::create(),
-                new RstSample([
-                    $codeBlock,
-                    '    $this->somePhp();',
                     '    return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);',
                 ], 2),
             ];

--- a/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
+++ b/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
@@ -60,7 +60,7 @@ final class UseNamedConstructorWithoutNewKeywordRuleTest extends UnitTestCase
                     '    $client = new NoPrivateNetworkHttpClient(HttpClient::create());',
                     '    $container->register(Ldap::class)->addArgument(new Reference(Adapter::class));',
                     '    new Status(Status::YES);',
-                    '    $response = new Response('Hello '.$name, Response::HTTP_OK);',
+                    '    return new Response(null, Response::HTTP_TOO_MANY_REQUESTS, $headers);',
                 ], 2),
             ];
         }

--- a/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
+++ b/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
@@ -59,6 +59,15 @@ final class UseNamedConstructorWithoutNewKeywordRuleTest extends UnitTestCase
                     '    new class();',
                 ], 2),
             ];
+
+            yield sprintf('No violation for code-block "%s"', $codeBlock) => [
+                NullViolation::create(),
+                new RstSample([
+                    $codeBlock,
+                    '    $this->somePhp();',
+                    '    return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);',
+                ], 2),
+            ];
         }
     }
 }


### PR DESCRIPTION
Following https://github.com/symfony/symfony-docs/pull/18168
Fixing #1372 