### PR TITLE
Add `RulesConfiguration`

### DIFF
--- a/src/Rule/NoDuplicateUseStatements.php
+++ b/src/Rule/NoDuplicateUseStatements.php
@@ -55,8 +55,8 @@ class NoDuplicateUseStatements extends AbstractRule implements LineContentRule
             $lines->next();
         }
 
-        foreach (array_count_values($statements) as $statement => $count){
-            if($count > 1){
+        foreach (array_count_values($statements) as $statement => $count) {
+            if (1 < $count) {
                 return Violation::from(
                     sprintf('Please remove duplication of "%s"', $statement),
                     $filename,

--- a/src/Value/RulesConfiguration.php
+++ b/src/Value/RulesConfiguration.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Value;
+
+use App\Rule\Rule;
+
+final class RulesConfiguration
+{
+    /**
+     * @var Rule[]
+     */
+    private array $rulesForAll = [];
+
+    public function addRuleForAll(Rule $rule): void
+    {
+        $this->rulesForAll[] = $rule;
+    }
+
+    public function setRulesForAll(array $rules): void
+    {
+        $this->rulesForAll = [];
+
+        foreach ($rules as $rule) {
+            $this->addRuleForAll($rule);
+        }
+    }
+
+    public function hasRulesForAll(): bool
+    {
+        return [] !== $this->rulesForAll;
+    }
+
+    /**
+     * @return Rule[]
+     */
+    public function getRulesForFilePath(string $filePath): array
+    {
+        return $this->rulesForAll;
+    }
+}

--- a/tests/Value/RulesConfigurationTest.php
+++ b/tests/Value/RulesConfigurationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Value;
+
+use App\Tests\Fixtures\Rule\DummyRule;
+use App\Value\RulesConfiguration;
+
+final class RulesConfigurationTest extends \App\Tests\UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function rulesForAll(): void
+    {
+        $rulesConfiguration = new RulesConfiguration();
+        self::assertFalse($rulesConfiguration->hasRulesForAll());
+
+        $firstRule = new DummyRule();
+        $rulesConfiguration->addRuleForAll($firstRule);
+        self::assertTrue($rulesConfiguration->hasRulesForAll());
+
+        self::assertSame(
+            [
+                $firstRule,
+            ],
+            $rulesConfiguration->getRulesForFilePath('foobar'),
+        );
+
+        $secondRule = new DummyRule();
+        $rulesConfiguration->addRuleForAll($secondRule);
+
+        self::assertSame(
+            [
+                $firstRule,
+                $secondRule,
+            ],
+            $rulesConfiguration->getRulesForFilePath('foobar'),
+        );
+
+        $rulesConfiguration->setRulesForAll([$secondRule]);
+
+        self::assertSame(
+            [
+                $secondRule,
+            ],
+            $rulesConfiguration->getRulesForFilePath('foobar'),
+        );
+    }
+}


### PR DESCRIPTION
To fix https://github.com/symfony/symfony-docs/pull/18295 we have to exclude file from all rules or add 15 `whitelist` rules in `.doctor-rst.yaml`.

This PR is needed to be able to exclude rule by file in a follow-up PR

```yaml
rules:
  ...
exclude_rule_for_file:
  - path: configuration/multiple_kernels.rst
    rule_name: replacement
```

Refs #1340