### PR TITLE
exclude `vendor/` dir from analysis

### DIFF
--- a/src/Command/AnalyzeCommand.php
+++ b/src/Command/AnalyzeCommand.php
@@ -153,7 +153,7 @@ class AnalyzeCommand extends Command
         $showValidFiles = $input->getOption('short') ? false : true;
 
         $finder = new Finder();
-        $finder->files()->name(['*.rst', '*.rst.inc'])->in($analyzeDir);
+        $finder->files()->name(['*.rst', '*.rst.inc'])->in($analyzeDir)->exclude('vendor');
 
         $whitelistConfig = $config['whitelist'] ?? [];
 


### PR DESCRIPTION
using https://github.com/OskarStark/doctor-rst/pull/1402 it was easy to see that we currently also analyze files from `vendor/`

----

I guess we can assume that people don't want to analyze `.rst` files from composer `vendor/` dir.

this reduces unnecessary IO / directory traversal of a potentially big `vendor/` dir