### PR TITLE
Prevent excessive use of `preg_match()`

### DIFF
--- a/src/Helper/PhpHelper.php
+++ b/src/Helper/PhpHelper.php
@@ -37,22 +37,22 @@ final class PhpHelper
 
     public static function isFirstLineOfMultilineComment(Line $line): bool
     {
-        return [] !== $line->clean()->equalsTo('/*');
+        return $line->clean()->equalsTo('/*');
     }
 
     public static function isLastLineOfMultilineComment(Line $line): bool
     {
-        return [] !== $line->clean()->equalsTo('*/');
+        return $line->clean()->equalsTo('*/');
     }
 
     public static function isFirstLineOfDocBlock(Line $line): bool
     {
-        return [] !== $line->clean()->equalsTo('/**');
+        return $line->clean()->equalsTo('/**');
     }
 
     public static function isLastLineOfDocBlock(Line $line): bool
     {
-        return [] !== $line->clean()->equalsTo('*/');
+        return $line->clean()->equalsTo('*/');
     }
 
     public function isPartOfDocBlock(Lines $lines, int $number): bool

--- a/src/Helper/PhpHelper.php
+++ b/src/Helper/PhpHelper.php
@@ -37,22 +37,22 @@ final class PhpHelper
 
     public static function isFirstLineOfMultilineComment(Line $line): bool
     {
-        return [] !== $line->clean()->match('/^\/\*$/');
+        return [] !== $line->clean()->equalsTo('/*');
     }
 
     public static function isLastLineOfMultilineComment(Line $line): bool
     {
-        return [] !== $line->clean()->match('/^\*\/$/');
+        return [] !== $line->clean()->equalsTo('*/');
     }
 
     public static function isFirstLineOfDocBlock(Line $line): bool
     {
-        return [] !== $line->clean()->match('/^\/\*\*$/');
+        return [] !== $line->clean()->equalsTo('/**');
     }
 
     public static function isLastLineOfDocBlock(Line $line): bool
     {
-        return [] !== $line->clean()->match('/^\*\/$/');
+        return [] !== $line->clean()->equalsTo('*/');
     }
 
     public function isPartOfDocBlock(Lines $lines, int $number): bool

--- a/src/Helper/PhpHelper.php
+++ b/src/Helper/PhpHelper.php
@@ -37,22 +37,22 @@ final class PhpHelper
 
     public static function isFirstLineOfMultilineComment(Line $line): bool
     {
-        return $line->clean()->equalsTo('/*');
+        return $line->clean()->toString() === '/*';
     }
 
     public static function isLastLineOfMultilineComment(Line $line): bool
     {
-        return $line->clean()->equalsTo('*/');
+        return $line->clean()->toString() === '*/';
     }
 
     public static function isFirstLineOfDocBlock(Line $line): bool
     {
-        return $line->clean()->equalsTo('/**');
+        return $line->clean()->toString() === '/**';
     }
 
     public static function isLastLineOfDocBlock(Line $line): bool
     {
-        return $line->clean()->equalsTo('*/');
+        return $line->clean()->toString() === '*/';
     }
 
     public function isPartOfDocBlock(Lines $lines, int $number): bool


### PR DESCRIPTION
I was not able to analyze symfony/docs yet, as analyzing the project required more then 16GB of ram.

therefore I do some babysteps first

Most important is that we safe a lot of memory

![grafik](https://github.com/OskarStark/doctor-rst/assets/120441/3156e4de-125a-45d7-90f6-8d3e583cc94a)

