### PR TITLE
`RstParser->isFootnote()`: Prevent excessive use of `preg_match()`

### DIFF
--- a/src/Rst/RstParser.php
+++ b/src/Rst/RstParser.php
@@ -230,7 +230,7 @@ class RstParser
     public static function isFootnote(Line $line): bool
     {
         $string = (string) $line->clean();
-        return $string[0] === '0' && $string[1] === '.' && $string[2] === ' ' && [] !== $line->clean()->match('/^\.\. \[[0-9]\]/');
+        return $string[0] === '.' && $string[1] === '.' && $string[2] === ' ' && [] !== $line->clean()->match('/^\.\. \[[0-9]\]/');
     }
 
     /**

--- a/src/Rst/RstParser.php
+++ b/src/Rst/RstParser.php
@@ -230,7 +230,13 @@ class RstParser
     public static function isFootnote(Line $line): bool
     {
         $string = (string) $line->clean();
-        return $string[0] === '.' && $string[1] === '.' && $string[2] === ' ' && [] !== $line->clean()->match('/^\.\. \[[0-9]\]/');
+        return strlen($string) >= 5
+            && $string[0] === '.'
+            && $string[1] === '.'
+            && $string[2] === ' '
+            && $string[3] === '['
+            && [] !== $line->clean()->match('/^\.\. \[[0-9]\]/'
+        );
     }
 
     /**

--- a/src/Rst/RstParser.php
+++ b/src/Rst/RstParser.php
@@ -132,9 +132,10 @@ class RstParser
 
         if (self::DIRECTIVE_CODE_BLOCK === $directive && (!$strict && $line->isDefaultDirective())) {
             $directivesExcludedCodeBlock = array_diff(self::DIRECTIVES, [$directive]);
+            $rawLine = $line->raw()->toString();
 
             foreach ($directivesExcludedCodeBlock as $other) {
-                if (str_contains($line->raw()->toString(), $other)) {
+                if (str_contains($rawLine, $other)) {
                     return false;
                 }
             }
@@ -228,7 +229,8 @@ class RstParser
      */
     public static function isFootnote(Line $line): bool
     {
-        return [] !== $line->clean()->match('/^\.\. \[[0-9]\]/');
+        $string = (string) $line->clean();
+        return $string[0] === '0' && $string[1] === '.' && $string[2] === ' ' && [] !== $line->clean()->match('/^\.\. \[[0-9]\]/');
     }
 
     /**


### PR DESCRIPTION
![grafik](https://github.com/OskarStark/doctor-rst/assets/120441/ff059bf4-bdd6-4e26-8f1a-328825415467)
