### PR TITLE
Relax `TitleUnderlineLengthMustMatchTitleLength` rule for short headings

### DIFF
--- a/src/Rule/TitleUnderlineLengthMustMatchTitleLength.php
+++ b/src/Rule/TitleUnderlineLengthMustMatchTitleLength.php
@@ -30,6 +30,13 @@ class TitleUnderlineLengthMustMatchTitleLength extends AbstractRule implements L
         }
 
         $headLineLength = mb_strlen($line->clean()->toString());
+        // needed because some headline contents only contain 1 or 2 characters;
+        // this causes issues with the Doctrine RST Parser, which requires 3 or more characters
+        // (see https://github.com/symfony/symfony-docs/issues/18289)
+        if ($headLineLength <= 3) {
+            return NullViolation::create();
+        }
+
         $lines->seek($number - 1);
 
         if ($lines->valid()

--- a/tests/Rule/TitleUnderlineLengthMustMatchTitleLengthTest.php
+++ b/tests/Rule/TitleUnderlineLengthMustMatchTitleLengthTest.php
@@ -78,6 +78,22 @@ final class TitleUnderlineLengthMustMatchTitleLengthTest extends \App\Tests\Unit
         yield [
             NullViolation::create(),
             new RstSample([
+                't',
+                '~',
+            ], 1),
+        ];
+
+        yield [
+            NullViolation::create(),
+            new RstSample([
+                'tt',
+                '~~',
+            ], 1),
+        ];
+
+        yield [
+            NullViolation::create(),
+            new RstSample([
                 'Title with matching underline',
                 '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~',
             ], 1),


### PR DESCRIPTION
Fixes the false positive in https://github.com/symfony/symfony-docs/pull/18361