### PR TITLE
Fix false positive in PhpPrefixBeforeBinConsole rule

### DIFF
--- a/src/Rule/PhpPrefixBeforeBinConsole.php
+++ b/src/Rule/PhpPrefixBeforeBinConsole.php
@@ -42,7 +42,7 @@ class PhpPrefixBeforeBinConsole extends AbstractRule implements LineContentRule
             return NullViolation::create();
         }
 
-        if (preg_match('/(`|"|_|├─ )bin\/console/u', $line->raw()->toString())
+        if (preg_match('/(`|"|_|├─ |\/\/ )bin\/console/u', $line->raw()->toString())
             || preg_match('/php "%s\/\.\.\/bin\/console"/', $line->raw()->toString())) {
             return NullViolation::create();
         }

--- a/tests/Rule/PhpPrefixBeforeBinConsoleTest.php
+++ b/tests/Rule/PhpPrefixBeforeBinConsoleTest.php
@@ -42,6 +42,7 @@ final class PhpPrefixBeforeBinConsoleTest extends \App\Tests\UnitTestCase
         yield [NullViolation::create(), new RstSample('.. _`copying Symfony\'s bin/console source`: https://github.com/symfony/recipes/blob/master/symfony/console/3.3/bin/console')];
         yield [NullViolation::create(), new RstSample('├─ bin/console')];
         yield [NullViolation::create(), new RstSample('Symfony\Component\Console\Application->run() at /home/greg/demo/bin/console:42')];
+        yield [NullViolation::create(), new RstSample('// bin/console')];
         yield [
             Violation::from(
                 'Please add "php" prefix before "bin/console"',


### PR DESCRIPTION
This will avoid this whitelist entry

https://github.com/symfony/symfony-docs/blob/7cc92d519f399fe49301030b428883880e5f3458/.doctor-rst.yaml#L103