### PR TITLE
`bin/console` in array is allowed

### DIFF
--- a/src/Rule/PhpPrefixBeforeBinConsole.php
+++ b/src/Rule/PhpPrefixBeforeBinConsole.php
@@ -42,7 +42,7 @@ class PhpPrefixBeforeBinConsole extends AbstractRule implements LineContentRule
             return NullViolation::create();
         }
 
-        if (preg_match('/(`|"|_|├─ |\/\/ )bin\/console/u', $line->raw()->toString())
+        if (preg_match('/((`|"|_|├─ |\/\/ )|\[\')bin\/console/u', $line->raw()->toString())
             || preg_match('/php "%s\/\.\.\/bin\/console"/', $line->raw()->toString())) {
             return NullViolation::create();
         }

--- a/tests/Rule/PhpPrefixBeforeBinConsoleTest.php
+++ b/tests/Rule/PhpPrefixBeforeBinConsoleTest.php
@@ -43,6 +43,7 @@ final class PhpPrefixBeforeBinConsoleTest extends \App\Tests\UnitTestCase
         yield [NullViolation::create(), new RstSample('├─ bin/console')];
         yield [NullViolation::create(), new RstSample('Symfony\Component\Console\Application->run() at /home/greg/demo/bin/console:42')];
         yield [NullViolation::create(), new RstSample('// bin/console')];
+        yield [NullViolation::create(), new RstSample('$childProcess = new PhpSubprocess([\'bin/console\', \'cache:pool:prune\']);')];
         yield [
             Violation::from(
                 'Please add "php" prefix before "bin/console"',


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/pull/18693#discussion_r1285417619