### PR TITLE
New rule: Ensure link are at the bottom of the file

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -22,6 +22,7 @@
 * [ensure_bash_prompt_before_composer_command](#ensure_bash_prompt_before_composer_command)
 * [ensure_exactly_one_space_before_directive_type](#ensure_exactly_one_space_before_directive_type)
 * [ensure_exactly_one_space_between_link_definition_and_link](#ensure_exactly_one_space_between_link_definition_and_link)
+* [ensure_link_bottom](#ensure_link_bottom)
 * [ensure_link_definition_contains_valid_url](#ensure_link_definition_contains_valid_url)
 * [ensure_order_of_code_blocks_in_configuration_block](#ensure_order_of_code_blocks_in_configuration_block)
 * [ensure_php_reference_syntax](#ensure_php_reference_syntax)
@@ -355,6 +356,12 @@ composer require symfony/var-dumper
 ```rst
 .. _DOCtor-RST:     https://github.com/OskarStark/DOCtor-RST
 ```
+
+## `ensure_link_bottom`
+
+  > _Ensure link lines are at the bottom of the file._
+
+#### Groups [`@Symfony`]
 
 ## `ensure_link_definition_contains_valid_url`
 

--- a/src/Rule/EnsureLinkBottom.php
+++ b/src/Rule/EnsureLinkBottom.php
@@ -53,7 +53,7 @@ class EnsureLinkBottom extends AbstractRule implements LineContentRule
 
             if (!RstParser::isLinkDefinition($current)) {
                 return Violation::from(
-                    'Please move link line at the bottom of the file',
+                    'Please move link definition to the bottom of the page',
                     $filename,
                     $number + 1,
                     $line,

--- a/src/Rule/EnsureLinkBottom.php
+++ b/src/Rule/EnsureLinkBottom.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Rule;
+
+use App\Attribute\Rule\Description;
+use App\Rst\RstParser;
+use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+
+#[Description('Ensure link lines are at the bottom of the file.')]
+class EnsureLinkBottom extends AbstractRule implements LineContentRule
+{
+    public static function getGroups(): array
+    {
+        return [RuleGroup::Symfony()];
+    }
+
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
+    {
+        $lines->seek($number);
+        $line = $lines->current();
+
+        if (!RstParser::isLinkDefinition($line)) {
+            return NullViolation::create();
+        }
+
+        while ($lines->valid()) {
+            $lines->next();
+
+            if (!$lines->valid()) {
+                break;
+            }
+
+            $current = $lines->current();
+
+            if ($current->isBlank()) {
+                continue;
+            }
+
+            if (!RstParser::isLinkDefinition($current)) {
+                return Violation::from(
+                    'Please move link line at the bottom of the file',
+                    $filename,
+                    $number + 1,
+                    $line,
+                );
+            }
+        }
+
+        return NullViolation::create();
+    }
+}

--- a/tests/Rule/EnsureLinkBottomTest.php
+++ b/tests/Rule/EnsureLinkBottomTest.php
@@ -64,7 +64,7 @@ final class EnsureLinkBottomTest extends UnitTestCase
 
         yield [
             Violation::from(
-                'Please move link line at the bottom of the file',
+                'Please move link definition to the bottom of the page',
                 'filename',
                 2,
                 '.. _`first-link`: https://foo.bar',
@@ -78,7 +78,7 @@ final class EnsureLinkBottomTest extends UnitTestCase
 
         yield [
             Violation::from(
-                'Please move link line at the bottom of the file',
+                'Please move link definition to the bottom of the page',
                 'filename',
                 2,
                 '.. _`first-link`: https://foo.bar',

--- a/tests/Rule/EnsureLinkBottomTest.php
+++ b/tests/Rule/EnsureLinkBottomTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Rule;
+
+use App\Rule\EnsureLinkBottom;
+use App\Tests\RstSample;
+use App\Tests\UnitTestCase;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+
+final class EnsureLinkBottomTest extends UnitTestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider checkProvider
+     */
+    public function check(ViolationInterface $expected, RstSample $sample): void
+    {
+        self::assertEquals(
+            $expected,
+            (new EnsureLinkBottom())->check($sample->lines, $sample->lineNumber, 'filename'),
+        );
+    }
+
+    /**
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
+     */
+    public static function checkProvider(): iterable
+    {
+        yield [
+            NullViolation::create(),
+            new RstSample('temp'),
+        ];
+
+        yield [
+            NullViolation::create(),
+            new RstSample([
+                '',
+                '.. _`first-link`: https://foo.bar',
+            ], 1),
+        ];
+
+        yield [
+            NullViolation::create(),
+            new RstSample([
+                '',
+                '.. _`first-link`: https://foo.bar',
+                '.. _`second-link`: https://foo.baz',
+            ], 1),
+        ];
+
+        yield [
+            Violation::from(
+                'Please move link line at the bottom of the file',
+                'filename',
+                2,
+                '.. _`first-link`: https://foo.bar',
+            ),
+            new RstSample([
+                '',
+                '.. _`first-link`: https://foo.bar',
+                'text after link',
+            ], 1),
+        ];
+
+        yield [
+            Violation::from(
+                'Please move link line at the bottom of the file',
+                'filename',
+                2,
+                '.. _`first-link`: https://foo.bar',
+            ),
+            new RstSample([
+                '',
+                '.. _`first-link`: https://foo.bar',
+                '',
+                'text after link',
+            ], 1),
+        ];
+    }
+}


### PR DESCRIPTION
Fix #1512


FYI when I run it on Symfony docs I have "only" 2 errors :smile: 

```txt
frontend/encore/faq.rst ✘
  140: Please move link line at the bottom of the file
   ->  .. _`rsync`: https://rsync.samba.org/
  171: Please move link line at the bottom of the file
   ->  .. _`Webpack integration in PhpStorm`: https://www.jetbrains.com/help/phpstorm/using-webpack.html

contributing/code/conventions.rst ✘
  184: Please move link line at the bottom of the file
   ->  .. _`ServiceRouterLoader`: https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Routing/Loader/DependencyInjection/ServiceRouterLoader.php
```