### PR TITLE
Use xargs to grep all files, not just the first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: tests-changed
 tests-changed: vendor doctrine
-	symfony php vendor/bin/phpunit --configuration=phpunit.xml.dist $(shell git diff HEAD --name-only | grep Test.php)
+	symfony php vendor/bin/phpunit --configuration=phpunit.xml.dist $(shell git diff HEAD --name-only | grep Test.php | xargs )
 
 .PHONY: tests
 tests:


### PR DESCRIPTION
_Created by [PR-Factory](https://github.com/datana-gmbh/pr-factory)_ using the following command:

```bash

symfony console \
   project:replace-in-file \
   grep Test.php) \
   grep Test.php | xargs ) \
   Makefile \
   --delete-branch-if-exists \
   --commit-message=Use xargs to grep all files, not just the first \
   -vv \
   all

```
