### PR TITLE
New rule : Ensure :class: :method: :namespace: starts with prefix

### DIFF
--- a/src/Rule/EnsureGithubDirectiveStartWithPrefix.php
+++ b/src/Rule/EnsureGithubDirectiveStartWithPrefix.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Rule;
+
+use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class EnsureGithubDirectiveStartWithPrefix extends AbstractRule implements Configurable, LineContentRule
+{
+    private string $prefix;
+
+    public function configureOptions(OptionsResolver $resolver): OptionsResolver
+    {
+        $resolver
+            ->setRequired('prefix')
+            ->setAllowedTypes('prefix', 'string');
+
+        return $resolver;
+    }
+
+    public function setOptions(array $options): void
+    {
+        $resolver = $this->configureOptions(new OptionsResolver());
+
+        $resolvedOptions = $resolver->resolve($options);
+
+        $this->prefix = $resolvedOptions['prefix'];
+    }
+
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
+    {
+        $lines->seek($number);
+        $line = $lines->current();
+
+        if ($line->clean()->match('/:(method|class|namespace):`.*`/') &&
+            !($line->clean()->match('/:(method|class|namespace):`'.$this->prefix.'\\\\.*`/'))) {
+
+            $message = sprintf(
+                'Please only use "%s" namespace with Github directive',
+                $this->prefix,
+            );
+            
+            return Violation::from(
+                $message,
+                $filename,
+                $number + 1,
+                $line,
+            );
+        }
+
+        return NullViolation::create();
+    }
+}

--- a/src/Rule/EnsureGithubDirectiveStartWithPrefix.php
+++ b/src/Rule/EnsureGithubDirectiveStartWithPrefix.php
@@ -15,7 +15,6 @@ namespace App\Rule;
 
 use App\Value\Lines;
 use App\Value\NullViolation;
-use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -51,7 +50,7 @@ class EnsureGithubDirectiveStartWithPrefix extends AbstractRule implements Confi
             !($line->clean()->match('/:(method|class|namespace):`'.$this->prefix.'\\\\.*`/'))) {
 
             $message = sprintf(
-                'Please only use "%s" namespace with Github directive',
+                'Please only use "%s" base namespace with Github directive',
                 $this->prefix,
             );
             

--- a/tests/Rule/EnsureGithubDirectiveStartWithPrefixTest.php
+++ b/tests/Rule/EnsureGithubDirectiveStartWithPrefixTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Rule;
+
+use App\Rule\EnsureGithubDirectiveStartWithPrefix;
+use App\Tests\RstSample;
+use App\Tests\UnitTestCase;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+
+final class EnsureGithubDirectiveStartWithPrefixTest extends UnitTestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider checkProvider
+     */
+    public function check(ViolationInterface $expected, string $prefix, RstSample $sample): void
+    {
+        $rule = (new EnsureGithubDirectiveStartWithPrefix());
+        $rule->setOptions(['min_version' => $prefix]);
+
+        self::assertEquals($expected, $rule->check($sample->lines, $sample->lineNumber, 'filename'));
+    }
+
+    /**
+     * @return \Generator<array{0: ViolationInterface, 1: string, 2: RstSample}>
+     */
+    public static function checkProvider(): iterable
+    {
+        yield [
+            NullViolation::create(),
+            'Symfony',
+            new RstSample('Using :class:`Symfony\\Component\\Cache\\Adapter\\PdoAdapter` is deprecated'),
+        ];
+        yield [
+            NullViolation::create(),
+            'Psr',
+            new RstSample('Implements the interface :class:`Psr\\Cache\\CacheItemPoolInterface`'),
+        ];
+        yield [
+            Violation::from(
+                'Please only use Symfony namespace with Github directive',
+                'filename',
+                1,
+                'Implements the interface :class:`Psr\\Cache\\CacheItemPoolInterface`',
+            ),
+            'Symfony',
+            new RstSample('Implements the interface :class:`Psr\\Cache\\CacheItemPoolInterface`'),
+        ];
+    }
+}

--- a/tests/Rule/EnsureGithubDirectiveStartWithPrefixTest.php
+++ b/tests/Rule/EnsureGithubDirectiveStartWithPrefixTest.php
@@ -30,7 +30,7 @@ final class EnsureGithubDirectiveStartWithPrefixTest extends UnitTestCase
     public function check(ViolationInterface $expected, string $prefix, RstSample $sample): void
     {
         $rule = (new EnsureGithubDirectiveStartWithPrefix());
-        $rule->setOptions(['min_version' => $prefix]);
+        $rule->setOptions(['prefix' => $prefix]);
 
         self::assertEquals($expected, $rule->check($sample->lines, $sample->lineNumber, 'filename'));
     }
@@ -52,7 +52,7 @@ final class EnsureGithubDirectiveStartWithPrefixTest extends UnitTestCase
         ];
         yield [
             Violation::from(
-                'Please only use Symfony namespace with Github directive',
+                'Please only use "Symfony" base namespace with Github directive',
                 'filename',
                 1,
                 'Implements the interface :class:`Psr\\Cache\\CacheItemPoolInterface`',


### PR DESCRIPTION
Trying to implement new rule for #1651 