### PR TITLE
Fix `EnsureGithubDirectiveStartWithPrefix` rule with named directive

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -22,6 +22,7 @@
 * [ensure_bash_prompt_before_composer_command](#ensure_bash_prompt_before_composer_command)
 * [ensure_exactly_one_space_before_directive_type](#ensure_exactly_one_space_before_directive_type)
 * [ensure_exactly_one_space_between_link_definition_and_link](#ensure_exactly_one_space_between_link_definition_and_link)
+* [ensure_github_directive_start_with_prefix](#ensure_github_directive_start_with_prefix)
 * [ensure_link_bottom](#ensure_link_bottom)
 * [ensure_link_definition_contains_valid_url](#ensure_link_definition_contains_valid_url)
 * [ensure_order_of_code_blocks_in_configuration_block](#ensure_order_of_code_blocks_in_configuration_block)
@@ -356,6 +357,14 @@ composer require symfony/var-dumper
 ```rst
 .. _DOCtor-RST:     https://github.com/OskarStark/DOCtor-RST
 ```
+
+## `ensure_github_directive_start_with_prefix`
+
+#### Configuration options
+
+Name | Required
+--- | ---
+`prefix` | `true` | `string`
 
 ## `ensure_link_bottom`
 

--- a/src/Rule/EnsureGithubDirectiveStartWithPrefix.php
+++ b/src/Rule/EnsureGithubDirectiveStartWithPrefix.php
@@ -47,7 +47,7 @@ class EnsureGithubDirectiveStartWithPrefix extends AbstractRule implements Confi
         $line = $lines->current();
 
         if ($line->clean()->match('/:(method|class|namespace):`.*`/') &&
-            !($line->clean()->match('/:(method|class|namespace):`'.$this->prefix.'\\\\.*`/'))) {
+            !($line->clean()->match('/:(method|class|namespace):`.*'.$this->prefix.'\\\\.*`/'))) {
 
             $message = sprintf(
                 'Please only use "%s" base namespace with Github directive',

--- a/tests/Rule/EnsureGithubDirectiveStartWithPrefixTest.php
+++ b/tests/Rule/EnsureGithubDirectiveStartWithPrefixTest.php
@@ -51,6 +51,11 @@ final class EnsureGithubDirectiveStartWithPrefixTest extends UnitTestCase
             new RstSample('Implements the interface :class:`Psr\\Cache\\CacheItemPoolInterface`'),
         ];
         yield [
+            NullViolation::create(),
+            'Symfony',
+            new RstSample('Or :method:`Form::submit() <Symfony\\Component\\Form\\Form::submit>`.'),
+        ];
+        yield [
             Violation::from(
                 'Please only use "Symfony" base namespace with Github directive',
                 'filename',
@@ -59,6 +64,16 @@ final class EnsureGithubDirectiveStartWithPrefixTest extends UnitTestCase
             ),
             'Symfony',
             new RstSample('Implements the interface :class:`Psr\\Cache\\CacheItemPoolInterface`'),
+        ];
+        yield [
+            Violation::from(
+                'Please only use "Psr" base namespace with Github directive',
+                'filename',
+                1,
+                'Or :method:`Form::submit() <Symfony\\Component\\Form\\Form::submit>`.',
+            ),
+            'Psr',
+            new RstSample('Or :method:`Form::submit() <Symfony\\Component\\Form\\Form::submit>`.'),
         ];
     }
 }


### PR DESCRIPTION
There is 16 false-positive on symfony 5.4 branch

For example

```
components/property_info.rst ✘
  267: Please only use "Symfony" base namespace with Github directive
   ->  :method:`PropertyInfoExtractor::getTypes() <Symfony\\Component\\PropertyInfo\\PropertyInfoExtractor::getTypes>`
  284: Please only use "Symfony" base namespace with Github directive
   ->  The :method:`Type::getBuiltinType() <Symfony\\Component\\PropertyInfo\\Type::getBuiltinType>`
  295: Please only use "Symfony" base namespace with Github directive
   ->  The :method:`Type::isNullable() <Symfony\\Component\\PropertyInfo\\Type::isNullable>`
  303: Please only use "Symfony" base namespace with Github directive
   ->  is ``object``, the :method:`Type::getClassName() <Symfony\\Component\\PropertyInfo\\Type::getClassName>`
  309: Please only use "Symfony" base namespace with Github directive
   ->  The :method:`Type::isCollection() <Symfony\\Component\\PropertyInfo\\Type::isCollection>`
  327: Please only use "Symfony" base namespace with Github directive
   ->  available), via the :method:`Type::getCollectionKeyTypes() <Symfony\\Component\\PropertyInfo\\Type::getCollectionKeyTypes>`
  328: Please only use "Symfony" base namespace with Github directive
   ->  and :method:`Type::getCollectionValueTypes() <Symfony\\Component\\PropertyInfo\\Type::getCollectionValueTypes>`
```