### PR TITLE
Build arm64 version

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -41,6 +41,7 @@ jobs:
               with:
                   push: true
                   builder: ${{ steps.buildx.outputs.name }}
+                  platforms: linux/amd64,linux/arm64
                   tags: |
                       ${{env.IMAGE}}:latest
                       ${{env.IMAGE}}:${{env.RELEASE_VERSION}}


### PR DESCRIPTION
I'm submitting this as a PR but it's more a question than anything :) 

Would you be ok to build ARM Docker images too ? That would ease the usage for macOS users.. but i can imagine it's not something you'd like to maintain :)