### PR TITLE
Fix Github annotation for rule TitleUnderlineLengthMustMatchTitleLength

### DIFF
--- a/src/Rule/TitleUnderlineLengthMustMatchTitleLength.php
+++ b/src/Rule/TitleUnderlineLengthMustMatchTitleLength.php
@@ -44,7 +44,6 @@ class TitleUnderlineLengthMustMatchTitleLength extends AbstractRule implements L
             && !$lines->current()->isBlank()
             && !(mb_strlen($lines->current()->clean()->toString()) === $headLineLength)
         ) {
-
             return Violation::from(
                 sprintf(
                     'Please ensure title "%s" and underline length are matching',

--- a/src/Rule/TitleUnderlineLengthMustMatchTitleLength.php
+++ b/src/Rule/TitleUnderlineLengthMustMatchTitleLength.php
@@ -44,10 +44,11 @@ class TitleUnderlineLengthMustMatchTitleLength extends AbstractRule implements L
             && !$lines->current()->isBlank()
             && !(mb_strlen($lines->current()->clean()->toString()) === $headLineLength)
         ) {
+
             return Violation::from(
                 sprintf(
                     'Please ensure title "%s" and underline length are matching',
-                    $lines->current()->raw()->replace('`', '')->toString(),
+                    $lines->current()->clean()->replace('`', '')->toString(),
                 ),
                 $filename,
                 $number,


### PR DESCRIPTION
Fix https://github.com/OskarStark/doctor-rst/issues/1704

[Github workflow command annotation ](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-creating-an-annotation-for-an-error) seems to not support multi-line

It's our case here

Before fix
![image](https://github.com/OskarStark/doctor-rst/assets/9253091/c9dd2ce0-9d4c-47ce-9b3c-1da817c7136b)

After fix

![image](https://github.com/OskarStark/doctor-rst/assets/9253091/0b89a4b4-d64b-473b-acd0-90708d054804)


We should not use `$lines->current()->raw()` in violation message to avoid this error.

(Phpunit is maybe green because we de `assertEquals` on objects, not 100% sure)