### PR TITLE
Fix EnsureExplicitNullableTypes

### DIFF
--- a/src/Rule/EnsureExplicitNullableTypes.php
+++ b/src/Rule/EnsureExplicitNullableTypes.php
@@ -48,13 +48,15 @@ class EnsureExplicitNullableTypes extends AbstractRule implements LineContentRul
         $lines->next();
 
         while ($lines->valid() && !$lines->current()->isDirective()) {
+            ++$number;
+
             if (!str_contains((string) $lines->current()->clean(), ' = null')) {
                 $lines->next();
 
                 continue;
             }
 
-            $pattern = '/([?]?\w+)\s+\$(\w+)\s*=\s*null(?=\s*[,\)])/';
+            $pattern = '#((?:\??\\\\?\w+[|]?)+)\s+\$(\w+)\s*=\s*null(?=\s*[,\)])#siu';
 
             if ($matches = $lines->current()->clean()->match($pattern, \PREG_SET_ORDER)) {
                 foreach ($matches as $match) {
@@ -62,6 +64,11 @@ class EnsureExplicitNullableTypes extends AbstractRule implements LineContentRul
 
                     // ?int $id = null
                     if (str_starts_with($types, '?')) {
+                        continue;
+                    }
+
+                    // mixed $id = null
+                    if ('mixed' === $types) {
                         continue;
                     }
 

--- a/tests/Rule/EnsureExplicitNullableTypesTest.php
+++ b/tests/Rule/EnsureExplicitNullableTypesTest.php
@@ -44,6 +44,10 @@ final class EnsureExplicitNullableTypesTest extends UnitTestCase
         $validCases = [
             'function foo(int $bar = 23)',
             'function foo(?int $bar = null)',
+            'function foo(?\\Throwable $exception = null)',
+            'function foo(\\Throwable|null $exception = null)',
+            'function foo(?Foo\\Bar $bar = null)',
+            'function foo(mixed $bar = null)',
             'function foo(int|null $bar = null)',
             'function foo(int|string|null $bar = null)',
         ];
@@ -51,7 +55,10 @@ final class EnsureExplicitNullableTypesTest extends UnitTestCase
         foreach ($validCases as $validCase) {
             yield $validCase => [
                 NullViolation::create(),
-                new RstSample(['.. code-block:: php', $validCase]),
+                new RstSample([
+                    '.. code-block:: php',
+                    '    '.$validCase,
+                ]),
             ];
         }
     }
@@ -63,6 +70,9 @@ final class EnsureExplicitNullableTypesTest extends UnitTestCase
     {
         $invalidCases = [
             'public function foo(int $bar = null)',
+            'public function foo(Throwable $bar = null)',
+            'public function foo(Foo\\Bar $bar = null)',
+            'public function foo(\\Throwable $bar = null)',
             'public function foo(int|string $bar = null)',
             'function foo(int $foo, int $bar = null)',
             'function foo(int $foo, int $bar = null, int $baz)',
@@ -76,10 +86,13 @@ final class EnsureExplicitNullableTypesTest extends UnitTestCase
                 Violation::from(
                     'Please use explicit nullable types.',
                     'filename',
-                    1,
+                    2,
                     $invalidCase,
                 ),
-                new RstSample(['.. code-block:: php', $invalidCase]),
+                new RstSample([
+                    '.. code-block:: php',
+                    '    '.$invalidCase,
+                ]),
             ];
         }
     }


### PR DESCRIPTION
Improve the regexp pattern to
* allow "mixed"
* allow fqcn (\Foo) & aliases (Foo\Bar)

Improve line number reporting (taken from #1714)