### PR TITLE
[rules] remove `ArgumentVariableMustMatchType` from `Symfony` group

### DIFF
--- a/src/Rule/ArgumentVariableMustMatchType.php
+++ b/src/Rule/ArgumentVariableMustMatchType.php
@@ -55,11 +55,6 @@ class ArgumentVariableMustMatchType extends AbstractRule implements Configurable
         $this->arguments = $resolvedOptions['arguments'];
     }
 
-    public static function getGroups(): array
-    {
-        return [RuleGroup::Symfony()];
-    }
-
     public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {
         $lines->seek($number);


### PR DESCRIPTION
Based on the discussion in https://github.com/symfony/symfony-docs/pull/19793 - the intent is to allow for

```diff
- public function loadExtension(array $config, ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void
+ public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
```

I'm assuming that symfony-docs use the `@symfony` rule group. 

_note: I'm still feeling my way around the code base - there may be more that needs to be done to solve the issues_