### PR TITLE
[Rule] No broken ref directive

### DIFF
--- a/src/Rule/NoBrokenRefDirective.php
+++ b/src/Rule/NoBrokenRefDirective.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Rule;
+
+use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+
+class NoBrokenRefDirective extends AbstractRule implements LineContentRule
+{
+    public static function getGroups(): array
+    {
+        return [RuleGroup::Symfony()];
+    }
+
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
+    {
+        $lines->seek($number);
+        $line = $lines->current();
+
+        if ($line->clean()->match('/ref/') && !$line->clean()->match('/:ref:/')) {
+            return Violation::from(
+                'Please use correct syntax for :ref: directive',
+                $filename,
+                $number + 1,
+                $line,
+            );
+        }
+
+        return NullViolation::create();
+    }
+}

--- a/tests/Rule/NoBrokenRefDirectiveTest.php
+++ b/tests/Rule/NoBrokenRefDirectiveTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Rule;
+
+use App\Rule\NoBrokenRefDirective;
+use App\Tests\RstSample;
+use App\Tests\UnitTestCase;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+
+final class NoBrokenRefDirectiveTest extends UnitTestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider checkProvider
+     */
+    public function check(ViolationInterface $expected, RstSample $sample): void
+    {
+        self::assertEquals(
+            $expected,
+            (new NoBrokenRefDirective())->check($sample->lines, $sample->lineNumber, 'filename'),
+        );
+    }
+
+    public static function checkProvider(): iterable
+    {
+        yield from [
+            [
+                Violation::from(
+                    'Please use correct syntax for :ref: directive',
+                    'filename',
+                    1,
+                    'ref `Redis section <messenger-redis-transport>` below',
+                ),
+                new RstSample('ref `Redis section <messenger-redis-transport>` below'),
+            ],
+            [
+                Violation::from(
+                    'Please use correct syntax for :ref: directive',
+                    'filename',
+                    1,
+                    'ref:`Redis section <messenger-redis-transport>` below',
+                ),
+                new RstSample('ref:`Redis section <messenger-redis-transport>` below'),
+            ],
+            [
+                Violation::from(
+                    'Please use correct syntax for :ref: directive',
+                    'filename',
+                    1,
+                    ':ref `Redis section <messenger-redis-transport>` below',
+                ),
+                new RstSample(':ref `Redis section <messenger-redis-transport>` below'),
+            ],
+            [
+                NullViolation::create(),
+                new RstSample(':ref:`Redis section <messenger-redis-transport>` below'),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Fix #1815 

First try for this new rule. 
I thought about using `:ref` and `ref:` as a pattern but as we don't use abbreviations in documentation we shouldn't have any false positives, what do you think about it ? 