### PR TITLE
Fix : correct pattern for no broken :ref: directive

### DIFF
--- a/src/Rule/NoBrokenRefDirective.php
+++ b/src/Rule/NoBrokenRefDirective.php
@@ -37,7 +37,7 @@ final class NoBrokenRefDirective extends AbstractRule implements LineContentRule
         $lines->seek($number);
         $line = $lines->current();
 
-        if ($line->clean()->match('/ref/') && !$line->clean()->match('/:ref:/')) {
+        if ($line->clean()->match('/(:ref|ref:)/') && !$line->clean()->match('/:ref:/')) {
             return Violation::from(
                 'Please use correct syntax for :ref: directive',
                 $filename,

--- a/tests/Rule/NoBrokenRefDirectiveTest.php
+++ b/tests/Rule/NoBrokenRefDirectiveTest.php
@@ -43,15 +43,6 @@ final class NoBrokenRefDirectiveTest extends UnitTestCase
                     'Please use correct syntax for :ref: directive',
                     'filename',
                     1,
-                    'ref `Redis section <messenger-redis-transport>` below',
-                ),
-                new RstSample('ref `Redis section <messenger-redis-transport>` below'),
-            ],
-            [
-                Violation::from(
-                    'Please use correct syntax for :ref: directive',
-                    'filename',
-                    1,
                     'ref:`Redis section <messenger-redis-transport>` below',
                 ),
                 new RstSample('ref:`Redis section <messenger-redis-transport>` below'),

--- a/tests/Rule/NoBrokenRefDirectiveTest.php
+++ b/tests/Rule/NoBrokenRefDirectiveTest.php
@@ -69,6 +69,10 @@ final class NoBrokenRefDirectiveTest extends UnitTestCase
                 NullViolation::create(),
                 new RstSample(':ref:`Redis section <messenger-redis-transport>` below'),
             ],
+            [
+                NullViolation::create(),
+                new RstSample('If you prefer to use'),
+            ],
         ];
     }
 }


### PR DESCRIPTION
I guess there is a way to ensure /ref/ will not match words like Reflexion, reference... but i can't find it and when using `preg_match` function outside of symfony-docs context there is no match :/ 

Then i suggest this as a fix, with a new test
The risk is to have false negative as this pattern will not match `ref` alone