### PR TITLE
Enhancement: Switch from `ergebnis/test-util` to `ergebnis/data-provider`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.45.0",
+        "ergebnis/data-provider": "^3.4",
         "ergebnis/php-cs-fixer-config": "^6.42.1",
-        "ergebnis/test-util": "^1.6",
         "icanhazstring/composer-unused": "^0.8.11",
         "maglnet/composer-require-checker": "^4.14",
         "mikey179/vfsstream": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "987e5e820d378712287ecb27be684e0c",
+    "content-hash": "12789be6b3fb29de042e33e5e38f54ab",
     "packages": [
         {
             "name": "composer/semver",
@@ -1674,72 +1674,6 @@
             "time": "2024-05-06T16:37:16+00:00"
         },
         {
-            "name": "ergebnis/classy",
-            "version": "1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ergebnis/classy.git",
-                "reference": "32880f00b442d0fcdb50df94ea8d45e48f9cb430"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/classy/zipball/32880f00b442d0fcdb50df94ea8d45e48f9cb430",
-                "reference": "32880f00b442d0fcdb50df94ea8d45e48f9cb430",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "require-dev": {
-                "ergebnis/composer-normalize": "^2.45.0",
-                "ergebnis/license": "^2.6.0",
-                "ergebnis/php-cs-fixer-config": "^6.40.0",
-                "ergebnis/phpunit-slow-test-detector": "^2.17.0",
-                "fakerphp/faker": "^1.24.1",
-                "infection/infection": "~0.26.6",
-                "phpstan/extension-installer": "^1.4.3",
-                "phpstan/phpstan": "^2.1.1",
-                "phpstan/phpstan-deprecation-rules": "^2.0.1",
-                "phpstan/phpstan-phpunit": "^2.0.3",
-                "phpstan/phpstan-strict-rules": "^2.0.1",
-                "phpunit/phpunit": "^9.6.19",
-                "rector/rector": "^2.0.6"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Ergebnis\\Classy\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com",
-                    "homepage": "https://localheinz.com"
-                }
-            ],
-            "description": "Provides a finder for classy constructs (classes, enums, interfaces, and traits).",
-            "homepage": "https://github.com/ergebnis/classy",
-            "keywords": [
-                "classes",
-                "classy",
-                "constructs",
-                "finder",
-                "interfaces",
-                "traits"
-            ],
-            "support": {
-                "issues": "https://github.com/ergebnis/classy/issues",
-                "source": "https://github.com/ergebnis/classy"
-            },
-            "time": "2025-01-07T10:31:33+00:00"
-        },
-        {
             "name": "ergebnis/composer-normalize",
             "version": "2.45.0",
             "source": {
@@ -1821,6 +1755,76 @@
                 "source": "https://github.com/ergebnis/composer-normalize"
             },
             "time": "2024-12-04T18:36:37+00:00"
+        },
+        {
+            "name": "ergebnis/data-provider",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/data-provider.git",
+                "reference": "a902a3d71c619bca787a9350ec313c5b34fb14c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/data-provider/zipball/a902a3d71c619bca787a9350ec313c5b34fb14c0",
+                "reference": "a902a3d71c619bca787a9350ec313c5b34fb14c0",
+                "shasum": ""
+            },
+            "require": {
+                "fakerphp/faker": "^1.21.0",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.44.0",
+                "ergebnis/license": "^2.6.0",
+                "ergebnis/php-cs-fixer-config": "^6.37.0",
+                "ergebnis/phpunit-slow-test-detector": "^2.16.1",
+                "infection/infection": "~0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.10",
+                "phpstan/phpstan-deprecation-rules": "^1.2.1",
+                "phpstan/phpstan-phpunit": "^1.4.0",
+                "phpstan/phpstan-strict-rules": "^1.6.1",
+                "phpunit/phpunit": "^9.6.19",
+                "rector/rector": "^1.2.10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.4-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\DataProvider\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides generic data providers for use with phpunit/phpunit.",
+            "homepage": "https://github.com/ergebnis/data-provider",
+            "keywords": [
+                "data-provider",
+                "phpunit"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/data-provider/issues",
+                "source": "https://github.com/ergebnis/data-provider"
+            },
+            "time": "2024-11-18T06:55:13+00:00"
         },
         {
             "name": "ergebnis/json",
@@ -2257,83 +2261,6 @@
                 "source": "https://github.com/ergebnis/php-cs-fixer-config"
             },
             "time": "2025-01-27T22:24:37+00:00"
-        },
-        {
-            "name": "ergebnis/test-util",
-            "version": "1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ergebnis/test-util.git",
-                "reference": "2f4a9b0670535ab88d64bd77cb50c218e49e6823"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/test-util/zipball/2f4a9b0670535ab88d64bd77cb50c218e49e6823",
-                "reference": "2f4a9b0670535ab88d64bd77cb50c218e49e6823",
-                "shasum": ""
-            },
-            "require": {
-                "ergebnis/classy": "^1.3.0",
-                "fakerphp/faker": "^1.17.0",
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ergebnis/composer-normalize": "^2.22.0",
-                "ergebnis/license": "^1.2.0",
-                "ergebnis/php-cs-fixer-config": "^3.4.0",
-                "ergebnis/phpstan-rules": "~0.15.3",
-                "infection/infection": "~0.25.5",
-                "phpstan/extension-installer": "^1.1.0",
-                "phpstan/phpstan": "~0.12.84",
-                "phpstan/phpstan-deprecation-rules": "~0.12.6",
-                "phpstan/phpstan-phpunit": "~0.12.22",
-                "phpstan/phpstan-strict-rules": "~0.12.11",
-                "phpunit/phpunit": "^9.5.11",
-                "psalm/plugin-phpunit": "~0.16.1",
-                "vimeo/psalm": "^4.17.0"
-            },
-            "type": "library",
-            "extra": {
-                "composer-normalize": {
-                    "indent-size": 2,
-                    "indent-style": "space"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Ergebnis\\Test\\Util\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com"
-                }
-            ],
-            "description": "Provides a helper trait and generic data providers for tests.",
-            "homepage": "https://github.com/ergebnis/test-util",
-            "keywords": [
-                "assertion",
-                "faker",
-                "phpunit",
-                "test"
-            ],
-            "support": {
-                "issues": "https://github.com/ergebnis/test-util/issues",
-                "source": "https://github.com/ergebnis/test-util"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/localheinz",
-                    "type": "github"
-                }
-            ],
-            "abandoned": "ergebnis/data-provider",
-            "time": "2022-01-03T18:31:15+00:00"
         },
         {
             "name": "erickskrauch/php-cs-fixer-custom-fixers",
@@ -6753,7 +6680,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -6762,6 +6689,6 @@
         "ext-iconv": "*",
         "ext-mbstring": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/UnitTestCase.php
+++ b/tests/UnitTestCase.php
@@ -14,22 +14,12 @@ declare(strict_types=1);
 namespace App\Tests;
 
 use App\Rst\RstParser;
+use Faker\Factory;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
 abstract class UnitTestCase extends TestCase
 {
-    final protected static function faker(string $locale = 'de_DE'): Generator
-    {
-        static $fakers = [];
-
-        if (!\array_key_exists($locale, $fakers)) {
-            $fakers[$locale] = new Generator();
-        }
-
-        return $fakers[$locale];
-    }
-
     /**
      * @return string[]
      */
@@ -52,5 +42,9 @@ abstract class UnitTestCase extends TestCase
         $result[] = 'A PHP code block follows::';
 
         return $result;
+    }
+    final protected static function faker(string $locale = 'de_DE'): Generator
+    {
+        return Factory::create($locale);
     }
 }

--- a/tests/UnitTestCase.php
+++ b/tests/UnitTestCase.php
@@ -14,10 +14,22 @@ declare(strict_types=1);
 namespace App\Tests;
 
 use App\Rst\RstParser;
+use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
 abstract class UnitTestCase extends TestCase
 {
+    final protected static function faker(string $locale = 'de_DE'): Generator
+    {
+        static $fakers = [];
+
+        if (!\array_key_exists($locale, $fakers)) {
+            $fakers[$locale] = new Generator();
+        }
+
+        return $fakers[$locale];
+    }
+
     /**
      * @return string[]
      */

--- a/tests/Value/RuleGroupTest.php
+++ b/tests/Value/RuleGroupTest.php
@@ -15,12 +15,9 @@ namespace App\Tests\Value;
 
 use App\Tests\UnitTestCase;
 use App\Value\RuleGroup;
-use Ergebnis\Test\Util\Helper;
 
 final class RuleGroupTest extends UnitTestCase
 {
-    use Helper;
-
     /**
      * @test
      */
@@ -34,8 +31,8 @@ final class RuleGroupTest extends UnitTestCase
     /**
      * @test
      *
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::blank()
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::empty()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::blank()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::empty()
      */
     public function fromStringThrowsException(string $value): void
     {

--- a/tests/Value/RuleNameTest.php
+++ b/tests/Value/RuleNameTest.php
@@ -15,18 +15,15 @@ namespace App\Tests\Value;
 
 use App\Tests\UnitTestCase;
 use App\Value\RuleName;
-use Ergebnis\Test\Util\Helper;
 
 final class RuleNameTest extends UnitTestCase
 {
-    use Helper;
-
     /**
      * @test
      */
     public function fromStringTrimsValue(): void
     {
-        $value = self::faker()->word;
+        $value = self::faker()->word();
         $untrimmed = ' '.$value.' ';
 
         self::assertSame(
@@ -40,7 +37,7 @@ final class RuleNameTest extends UnitTestCase
      */
     public function fromString(): void
     {
-        $value = self::faker()->word;
+        $value = self::faker()->word();
 
         self::assertSame(
             $value,
@@ -73,8 +70,8 @@ final class RuleNameTest extends UnitTestCase
     /**
      * @test
      *
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::blank()
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::empty()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::blank()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::empty()
      */
     public function fromStringThrowsException(string $value): void
     {
@@ -86,8 +83,8 @@ final class RuleNameTest extends UnitTestCase
     /**
      * @test
      *
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::blank()
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::empty()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::blank()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::empty()
      */
     public function fromClassStringThrowsException(string $value): void
     {


### PR DESCRIPTION
Refs

* https://github.com/sensiolabs-de/global/issues/11

_Created by [PR-Factory](https://github.com/sensiolabs-de/pr-factory)_ using the following command:

```bash

/Users/oskar.stark/dev/sensio/pr-factory/bin/console \
   project:ergebnis:replace-test-util \
   --delete-branch-if-exists \
   -vv \
   all

```
