### PR TITLE
New rule: `NoEmptyLiterals`

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -62,6 +62,7 @@
 * [no_contraction](#no_contraction)
 * [no_directive_after_shorthand](#no_directive_after_shorthand)
 * [no_duplicate_use_statements](#no_duplicate_use_statements)
+* [no_empty_literals](#no_empty_literals)
 * [no_explicit_use_of_code_block_php](#no_explicit_use_of_code_block_php)
 * [no_footnotes](#no_footnotes)
 * [no_inheritdoc_in_code_examples](#no_inheritdoc_in_code_examples)
@@ -766,6 +767,24 @@ It's an example
   > _Ensure there is not same use statement twice_
 
 #### Groups [`@Symfony`]
+
+## `no_empty_literals`
+
+  > _Make sure that no empty literals are used._
+
+#### Groups [`@Sonata`, `@Symfony`]
+
+##### Valid Examples :+1:
+
+```rst
+Please use ``foo``...
+```
+
+##### Invalid Examples :-1:
+
+```rst
+Please use ````...
+```
 
 ## `no_explicit_use_of_code_block_php`
 

--- a/src/Rule/NoEmptyLiterals.php
+++ b/src/Rule/NoEmptyLiterals.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Rule;
+
+use App\Attribute\Rule\Description;
+use App\Attribute\Rule\InvalidExample;
+use App\Attribute\Rule\ValidExample;
+use App\Traits\DirectiveTrait;
+use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+
+#[Description('Make sure that no empty literals are used.')]
+#[ValidExample('Please use ``foo``...')]
+#[InvalidExample('Please use ````...')]
+final class NoEmptyLiterals extends AbstractRule implements LineContentRule
+{
+    use DirectiveTrait;
+
+    public static function getGroups(): array
+    {
+        return [
+            RuleGroup::Sonata(),
+            RuleGroup::Symfony(),
+        ];
+    }
+
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
+    {
+        $lines->seek($number);
+        $line = $lines->current();
+
+        if (!$line->clean()->containsAny('````')) {
+            return NullViolation::create();
+        }
+
+        return Violation::from(
+            'Empty literals (````) are not allowed!',
+            $filename,
+            $number + 1,
+            $line,
+        );
+    }
+}

--- a/tests/Rule/NoEmptyLiteralsTest.php
+++ b/tests/Rule/NoEmptyLiteralsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Rule;
+
+use App\Rule\NoEmptyLiterals;
+use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+
+final class NoEmptyLiteralsTest extends AbstractLineContentRuleTestCase
+{
+    public function createRule(): NoEmptyLiterals
+    {
+        return new NoEmptyLiterals();
+    }
+
+    public static function checkProvider(): iterable
+    {
+        $invalid = 'Please use ````...';
+        $valid = 'Please use ``foo``...';
+
+        yield 'valid' => [NullViolation::create(), new RstSample($valid)];
+
+        yield 'invalid' => [
+            Violation::from(
+                'Empty literals (````) are not allowed!',
+                'filename',
+                1,
+                $invalid,
+            ),
+            new RstSample($invalid),
+        ];
+    }
+}


### PR DESCRIPTION
closes #1949 

@stof, a little bit dirty, but should do the trick