### PR TITLE
New rule: EnsureCodeBlockIndentation

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -21,6 +21,7 @@
 * [deprecated_directive_should_have_version](#deprecated_directive_should_have_version)
 * [ensure_bash_prompt_before_composer_command](#ensure_bash_prompt_before_composer_command)
 * [ensure_class_constant](#ensure_class_constant)
+* [ensure_code_block_indentation](#ensure_code_block_indentation)
 * [ensure_correct_format_for_phpfunction](#ensure_correct_format_for_phpfunction)
 * [ensure_exactly_one_space_before_directive_type](#ensure_exactly_one_space_before_directive_type)
 * [ensure_exactly_one_space_between_link_definition_and_link](#ensure_exactly_one_space_between_link_definition_and_link)
@@ -342,6 +343,24 @@ MyClass::class
 
 ```rst
 get_class(new MyClass())
+```
+
+## `ensure_code_block_indentation`
+
+  > _Ensure code blocks are indented by 4 spaces._
+
+#### Groups [`@Symfony`]
+
+##### Valid Examples :+1:
+
+```rst
+  .. code-block:: yml
+```
+
+##### Invalid Examples :-1:
+
+```rst
+   .. code-block:: yml
 ```
 
 ## `ensure_correct_format_for_phpfunction`

--- a/src/Rule/EnsureCodeBlockIndentation.php
+++ b/src/Rule/EnsureCodeBlockIndentation.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Rule;
+
+use App\Attribute\Rule\Description;
+use App\Attribute\Rule\InvalidExample;
+use App\Attribute\Rule\ValidExample;
+use App\Rst\RstParser;
+use App\Value\Line;
+use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+
+#[Description('Ensure code blocks are indented by 4 spaces.')]
+#[InvalidExample('   .. code-block:: yml')]
+#[ValidExample('  .. code-block:: yml')]
+class EnsureCodeBlockIndentation extends AbstractRule implements LineContentRule
+{
+    public static function getGroups(): array
+    {
+        return [
+            RuleGroup::Symfony(),
+        ];
+    }
+
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
+    {
+        $lines->seek($number);
+        $line = $lines->current();
+
+        if (!RstParser::directiveIs($line, RstParser::DIRECTIVE_CODE_BLOCK)) {
+            return NullViolation::create();
+        }
+
+        $spaces = $this->countSpaces($line);
+
+        if (0 !== ($spaces % 4)) {
+            $message = \sprintf(
+                'Please indent code block with multiple of 4 spaces, or zero. Actually %d space(s)',
+                $spaces,
+            );
+
+            return Violation::from(
+                $message,
+                $filename,
+                $number + 1,
+                $line,
+            );
+        }
+
+        return NullViolation::create();
+    }
+
+    private function countSpaces(Line $line): int
+    {
+        $matches = $line->raw()->match('/^(?<spaces>\s*)\.\./');
+
+        if (!$matches) {
+            return 0;
+        }
+
+        return mb_strlen($matches['spaces']);
+    }
+}

--- a/tests/Rule/EnsureCodeBlockIndentationTest.php
+++ b/tests/Rule/EnsureCodeBlockIndentationTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Rule;
+
+use App\Rule\EnsureCodeBlockIndentation;
+use App\Tests\RstSample;
+use App\Tests\UnitTestCase;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class EnsureCodeBlockIndentationTest extends UnitTestCase
+{
+    #[Test]
+    #[DataProvider('checkProvider')]
+    public function check(ViolationInterface $expected, RstSample $sample): void
+    {
+        self::assertEquals(
+            $expected,
+            (new EnsureCodeBlockIndentation())->check($sample->lines, $sample->lineNumber, 'filename'),
+        );
+    }
+
+    /**
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
+     */
+    public static function checkProvider(): iterable
+    {
+        yield [
+            NullViolation::create(),
+            new RstSample([
+                '',
+                '.. code-block:: yml',
+            ], 1),
+        ];
+
+        yield [
+            Violation::from(
+                'Please indent code block with multiple of 4 spaces, or zero. Actually 1 space(s)',
+                'filename',
+                2,
+                '.. code-block:: yml',
+            ),
+            new RstSample([
+                '',
+                ' .. code-block:: yml',
+            ], 1),
+        ];
+
+        yield [
+            NullViolation::create(),
+            new RstSample([
+                '',
+                '    .. code-block:: yml',
+            ], 1),
+        ];
+
+        yield [
+            Violation::from(
+                'Please indent code block with multiple of 4 spaces, or zero. Actually 5 space(s)',
+                'filename',
+                2,
+                '.. code-block:: yml',
+            ),
+            new RstSample([
+                '',
+                '     .. code-block:: yml',
+            ], 1),
+        ];
+    }
+}


### PR DESCRIPTION
Follow https://github.com/symfony/symfony-docs/pull/21033#issuecomment-2929049057

What do you think of the following report ? Is it correct ?

```txt
root@7a113d89c4db:/app# php bin/doctor-rst analyse yolo --short --no-cache
 Analyze *.rst(.inc) files in: /app/yolo
 Used config file:             /app/yolo/.doctor-rst.yaml

service_container/import.rst ✘
  161: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: yaml
  238: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: yaml

configuration/secrets.rst ✘
  263: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: terminal
  272: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: terminal

setup/upgrade_major.rst ✘
  327: Please indent code block with multiple of 4 spaces, or zero. Actually 7 space(s)
   ->  .. code-block:: terminal
  349: Please indent code block with multiple of 4 spaces, or zero. Actually 7 space(s)
   ->  .. code-block:: terminal

setup/flex.rst ✘
   41: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: terminal
   49: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: terminal
   57: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: diff
   73: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: terminal
   85: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: terminal

translation.rst ✘
 1050: Please indent code block with multiple of 4 spaces, or zero. Actually 7 space(s)
   ->  .. code-block:: yaml
 1058: Please indent code block with multiple of 4 spaces, or zero. Actually 7 space(s)
   ->  .. code-block:: xml
 1078: Please indent code block with multiple of 4 spaces, or zero. Actually 7 space(s)
   ->  .. code-block:: php

contributing/code/standards.rst ✘
  183: Please indent code block with multiple of 4 spaces, or zero. Actually 2 space(s)
   ->  .. code-block:: diff
  193: Please indent code block with multiple of 4 spaces, or zero. Actually 2 space(s)
   ->  .. code-block:: diff

contributing/documentation/standards.rst ✘
  141: Please indent code block with multiple of 4 spaces, or zero. Actually 2 space(s)
   ->  .. code-block:: text

contributing/community/reviews.rst ✘
  170: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: terminal
  178: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: terminal

security.rst ✘
 1173: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: json
 1185: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: json

deployment/proxies.rst ✘
  149: Please indent code block with multiple of 4 spaces, or zero. Actually 3 space(s)
   ->  .. code-block:: yaml

reference/formats/yaml.rst ✘
  322: Please indent code block with multiple of 4 spaces, or zero. Actually 2 space(s)
   ->  .. code-block:: yaml
  331: Please indent code block with multiple of 4 spaces, or zero. Actually 2 space(s)
   ->  .. code-block:: yaml
  339: Please indent code block with multiple of 4 spaces, or zero. Actually 2 space(s)
   ->  .. code-block:: yaml
  350: Please indent code block with multiple of 4 spaces, or zero. Actually 2 space(s)
   ->  .. code-block:: yaml

frontend/encore/vuejs.rst ✘
  203: Please indent code block with multiple of 4 spaces, or zero. Actually 1 space(s)
   ->  .. code-block:: twig

frontend/create_ux_bundle.rst ✘
   78: Please indent code block with multiple of 4 spaces, or zero. Actually 7 space(s)
   ->  .. code-block:: json
   98: Please indent code block with multiple of 4 spaces, or zero. Actually 7 space(s)
   ->  .. code-block:: javascript

                                                                                                                        
 [WARNING] Found "13" invalid files!                                                                                    
                                                                                                                        ```