### PR TITLE
Add references to rules.md

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -134,6 +134,11 @@ This is a nice behavior...
 This is a nice behaviour...
 ```
 
+#### References
+
+- Rule class: [App\Rule\AmericanEnglish](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/AmericanEnglish.php)
+- Test class: [App\Tests\Rule\AmericanEnglishTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/AmericanEnglishTest.php)
+
 ## `argument_variable_must_match_type`
 
   > _Make sure argument variable name match for type_
@@ -143,6 +148,11 @@ This is a nice behaviour...
 Name | Required | Allowed Types | Default
 --- | --- | --- | ---
 `arguments` | `false` | `array` | `[]`
+
+#### References
+
+- Rule class: [App\Rule\ArgumentVariableMustMatchType](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ArgumentVariableMustMatchType.php)
+- Test class: [App\Tests\Rule\ArgumentVariableMustMatchTypeTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/ArgumentVariableMustMatchTypeTest.php)
 
 ## `avoid_repetetive_words`
 
@@ -161,6 +171,11 @@ Please do not use it this way...
 ```rst
 Please do not not use it this way...
 ```
+
+#### References
+
+- Rule class: [App\Rule\AvoidRepetetiveWords](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/AvoidRepetetiveWords.php)
+- Test class: [App\Tests\Rule\AvoidRepetetiveWordsTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/AvoidRepetetiveWordsTest.php)
 
 ## `be_kind_to_newcomers`
 
@@ -182,11 +197,20 @@ Pattern | Message
 `/merely/i` | Please remove the word: %s
 `/basic/i` | Please remove the word: %s
 
+#### References
+
+- Rule class: [App\Rule\BeKindToNewcomers](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/BeKindToNewcomers.php)
+
 ## `blank_line_after_anchor`
 
   > _Make sure you have a blank line after anchor (`.. anchor:`)._
 
 #### Groups [`@Sonata`, `@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\BlankLineAfterAnchor](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/BlankLineAfterAnchor.php)
+- Test class: [App\Tests\Rule\BlankLineAfterAnchorTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/BlankLineAfterAnchorTest.php)
 
 ## `blank_line_after_colon`
 
@@ -194,11 +218,21 @@ Pattern | Message
 
 #### Groups [`@Sonata`, `@Symfony`]
 
+#### References
+
+- Rule class: [App\Rule\BlankLineAfterColon](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/BlankLineAfterColon.php)
+- Test class: [App\Tests\Rule\BlankLineAfterColonTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/BlankLineAfterColonTest.php)
+
 ## `blank_line_after_directive`
 
   > _Make sure you have a blank line after each directive._
 
 #### Groups [`@Sonata`, `@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\BlankLineAfterDirective](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/BlankLineAfterDirective.php)
+- Test class: [App\Tests\Rule\BlankLineAfterDirectiveTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/BlankLineAfterDirectiveTest.php)
 
 ## `blank_line_after_filepath_in_code_block`
 
@@ -206,27 +240,57 @@ Pattern | Message
 
 #### Groups [`@Sonata`, `@Symfony`]
 
+#### References
+
+- Rule class: [App\Rule\BlankLineAfterFilepathInCodeBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/BlankLineAfterFilepathInCodeBlock.php)
+- Test class: [App\Tests\Rule\BlankLineAfterFilepathInCodeBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/BlankLineAfterFilepathInCodeBlockTest.php)
+
 ## `blank_line_after_filepath_in_php_code_block`
 
   > _Make sure you have a blank line after a filepath in a PHP code block._
+
+#### References
+
+- Rule class: [App\Rule\BlankLineAfterFilepathInPhpCodeBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/BlankLineAfterFilepathInPhpCodeBlock.php)
+- Test class: [App\Tests\Rule\BlankLineAfterFilepathInPhpCodeBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/BlankLineAfterFilepathInPhpCodeBlockTest.php)
 
 ## `blank_line_after_filepath_in_twig_code_block`
 
   > _Make sure you have a blank line after a filepath in a Twig code block._
 
+#### References
+
+- Rule class: [App\Rule\BlankLineAfterFilepathInTwigCodeBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/BlankLineAfterFilepathInTwigCodeBlock.php)
+- Test class: [App\Tests\Rule\BlankLineAfterFilepathInTwigCodeBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/BlankLineAfterFilepathInTwigCodeBlockTest.php)
+
 ## `blank_line_after_filepath_in_xml_code_block`
 
   > _Make sure you have a blank line after a filepath in a XML code block._
 
+#### References
+
+- Rule class: [App\Rule\BlankLineAfterFilepathInXmlCodeBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/BlankLineAfterFilepathInXmlCodeBlock.php)
+- Test class: [App\Tests\Rule\BlankLineAfterFilepathInXmlCodeBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/BlankLineAfterFilepathInXmlCodeBlockTest.php)
+
 ## `blank_line_after_filepath_in_yaml_code_block`
 
   > _Make sure you have a blank line after a filepath in a YAML code block._
+
+#### References
+
+- Rule class: [App\Rule\BlankLineAfterFilepathInYamlCodeBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/BlankLineAfterFilepathInYamlCodeBlock.php)
+- Test class: [App\Tests\Rule\BlankLineAfterFilepathInYamlCodeBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/BlankLineAfterFilepathInYamlCodeBlockTest.php)
 
 ## `blank_line_before_directive`
 
   > _Make sure you have a blank line before each directive._
 
 #### Groups [`@Sonata`, `@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\BlankLineBeforeDirective](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/BlankLineBeforeDirective.php)
+- Test class: [App\Tests\Rule\BlankLineBeforeDirectiveTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/BlankLineBeforeDirectiveTest.php)
 
 ## `composer_dev_option_at_the_end`
 
@@ -246,6 +310,11 @@ composer require symfony/var-dumper --dev
 composer require --dev symfony/var-dumper
 ```
 
+#### References
+
+- Rule class: [App\Rule\ComposerDevOptionAtTheEnd](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ComposerDevOptionAtTheEnd.php)
+- Test class: [App\Tests\Rule\ComposerDevOptionAtTheEndTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/ComposerDevOptionAtTheEndTest.php)
+
 ## `composer_dev_option_not_at_the_end`
 
   > _Make sure Composer `--dev` option for `require` command is not used at the end._
@@ -264,9 +333,18 @@ composer require --dev symfony/var-dumper
 composer require symfony/var-dumper --dev
 ```
 
+#### References
+
+- Rule class: [App\Rule\ComposerDevOptionNotAtTheEnd](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ComposerDevOptionNotAtTheEnd.php)
+- Test class: [App\Tests\Rule\ComposerDevOptionNotAtTheEndTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/ComposerDevOptionNotAtTheEndTest.php)
+
 ## `correct_code_block_directive_based_on_the_content`
 
 #### Groups [`@Sonata`, `@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\CorrectCodeBlockDirectiveBasedOnTheContent](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/CorrectCodeBlockDirectiveBasedOnTheContent.php)
 
 ## `deprecated_directive_major_version`
 
@@ -278,6 +356,11 @@ Name | Required
 --- | ---
 `major_version` | `true` | `int`
 
+#### References
+
+- Rule class: [App\Rule\DeprecatedDirectiveMajorVersion](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/DeprecatedDirectiveMajorVersion.php)
+- Test class: [App\Tests\Rule\DeprecatedDirectiveMajorVersionTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/DeprecatedDirectiveMajorVersionTest.php)
+
 ## `deprecated_directive_min_version`
 
 #### Groups [`@Symfony`]
@@ -287,6 +370,11 @@ Name | Required
 Name | Required
 --- | ---
 `min_version` | `true` | `string`
+
+#### References
+
+- Rule class: [App\Rule\DeprecatedDirectiveMinVersion](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/DeprecatedDirectiveMinVersion.php)
+- Test class: [App\Tests\Rule\DeprecatedDirectiveMinVersionTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/DeprecatedDirectiveMinVersionTest.php)
 
 ## `deprecated_directive_should_have_version`
 
@@ -310,6 +398,11 @@ Name | Required
 .. deprecated:: foo-bar
 ```
 
+#### References
+
+- Rule class: [App\Rule\DeprecatedDirectiveShouldHaveVersion](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/DeprecatedDirectiveShouldHaveVersion.php)
+- Test class: [App\Tests\Rule\DeprecatedDirectiveShouldHaveVersionTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/DeprecatedDirectiveShouldHaveVersionTest.php)
+
 ## `ensure_bash_prompt_before_composer_command`
 
   > _Make sure Composer command in a terminal/bash code block is prefixed with a $._
@@ -328,6 +421,11 @@ $ composer require symfony/var-dumper
 composer require symfony/var-dumper
 ```
 
+#### References
+
+- Rule class: [App\Rule\EnsureBashPromptBeforeComposerCommand](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/EnsureBashPromptBeforeComposerCommand.php)
+- Test class: [App\Tests\Rule\EnsureBashPromptBeforeComposerCommandTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/EnsureBashPromptBeforeComposerCommandTest.php)
+
 ## `ensure_class_constant`
 
   > _Make sure to use ::class over get_class_
@@ -344,6 +442,11 @@ MyClass::class
 get_class(new MyClass())
 ```
 
+#### References
+
+- Rule class: [App\Rule\EnsureClassConstant](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/EnsureClassConstant.php)
+- Test class: [App\Tests\Rule\EnsureClassConstantTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/EnsureClassConstantTest.php)
+
 ## `ensure_correct_format_for_phpfunction`
 
   > _Ensure phpfunction directive do not end with ()._
@@ -359,6 +462,11 @@ get_class(new MyClass())
 ```rst
 :phpfunction:`mb_detect_encoding()`.
 ```
+
+#### References
+
+- Rule class: [App\Rule\EnsureCorrectFormatForPhpfunction](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/EnsureCorrectFormatForPhpfunction.php)
+- Test class: [App\Tests\Rule\EnsureCorrectFormatForPhpfunctionTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/EnsureCorrectFormatForPhpfunctionTest.php)
 
 ## `ensure_exactly_one_space_before_directive_type`
 
@@ -378,6 +486,11 @@ get_class(new MyClass())
 ..  code-block:: php
 ```
 
+#### References
+
+- Rule class: [App\Rule\EnsureExactlyOneSpaceBeforeDirectiveType](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/EnsureExactlyOneSpaceBeforeDirectiveType.php)
+- Test class: [App\Tests\Rule\EnsureExactlyOneSpaceBeforeDirectiveTypeTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/EnsureExactlyOneSpaceBeforeDirectiveTypeTest.php)
+
 ## `ensure_exactly_one_space_between_link_definition_and_link`
 
   > _Ensure exactly one space between link definition and link._
@@ -395,6 +508,11 @@ get_class(new MyClass())
 ```rst
 .. _DOCtor-RST:     https://github.com/OskarStark/DOCtor-RST
 ```
+
+#### References
+
+- Rule class: [App\Rule\EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink.php)
+- Test class: [App\Tests\Rule\EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest.php)
 
 ## `ensure_explicit_nullable_types`
 
@@ -418,6 +536,11 @@ function foo(string|null $bar = null)
 function foo(string $bar = null)
 ```
 
+#### References
+
+- Rule class: [App\Rule\EnsureExplicitNullableTypes](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/EnsureExplicitNullableTypes.php)
+- Test class: [App\Tests\Rule\EnsureExplicitNullableTypesTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/EnsureExplicitNullableTypesTest.php)
+
 ## `ensure_github_directive_start_with_prefix`
 
 #### Configuration options
@@ -426,11 +549,21 @@ Name | Required
 --- | ---
 `prefix` | `true` | `string`
 
+#### References
+
+- Rule class: [App\Rule\EnsureGithubDirectiveStartWithPrefix](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/EnsureGithubDirectiveStartWithPrefix.php)
+- Test class: [App\Tests\Rule\EnsureGithubDirectiveStartWithPrefixTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/EnsureGithubDirectiveStartWithPrefixTest.php)
+
 ## `ensure_link_bottom`
 
   > _Ensure link lines are at the bottom of the file._
 
 #### Groups [`@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\EnsureLinkBottom](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/EnsureLinkBottom.php)
+- Test class: [App\Tests\Rule\EnsureLinkBottomTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/EnsureLinkBottomTest.php)
 
 ## `ensure_link_definition_contains_valid_url`
 
@@ -450,9 +583,19 @@ Name | Required
 .. _DOCtor-RST: htt//github.com/OskarStark/DOCtor-RST
 ```
 
+#### References
+
+- Rule class: [App\Rule\EnsureLinkDefinitionContainsValidUrl](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/EnsureLinkDefinitionContainsValidUrl.php)
+- Test class: [App\Tests\Rule\EnsureLinkDefinitionContainsValidUrlTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/EnsureLinkDefinitionContainsValidUrlTest.php)
+
 ## `ensure_order_of_code_blocks_in_configuration_block`
 
 #### Groups [`@Sonata`, `@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\EnsureOrderOfCodeBlocksInConfigurationBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/EnsureOrderOfCodeBlocksInConfigurationBlock.php)
+- Test class: [App\Tests\Rule\EnsureOrderOfCodeBlocksInConfigurationBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/EnsureOrderOfCodeBlocksInConfigurationBlockTest.php)
 
 ## `ensure_php_reference_syntax`
 
@@ -472,11 +615,21 @@ The :class:`Symfony\Component\Notifier\Transport` class
 The :class:`Symfony\Component\Notifier\Transport`` class
 ```
 
+#### References
+
+- Rule class: [App\Rule\EnsurePhpReferenceSyntax](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/EnsurePhpReferenceSyntax.php)
+- Test class: [App\Tests\Rule\EnsurePhpReferenceSyntaxTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/EnsurePhpReferenceSyntaxTest.php)
+
 ## `extend_abstract_admin`
 
   > _Ensure `AbstractAdmin` and the corresponding namespace `Sonata\AdminBundle\Admin\AbstractAdmin` is used._
 
 #### Groups [`@Sonata`]
+
+#### References
+
+- Rule class: [App\Rule\ExtendAbstractAdmin](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ExtendAbstractAdmin.php)
+- Test class: [App\Tests\Rule\ExtendAbstractAdminTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/ExtendAbstractAdminTest.php)
 
 ## `extend_abstract_controller`
 
@@ -484,11 +637,21 @@ The :class:`Symfony\Component\Notifier\Transport`` class
 
 #### Groups [`@Symfony`]
 
+#### References
+
+- Rule class: [App\Rule\ExtendAbstractController](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ExtendAbstractController.php)
+- Test class: [App\Tests\Rule\ExtendAbstractControllerTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/ExtendAbstractControllerTest.php)
+
 ## `extend_controller`
 
   > _Ensure `Controller` and the corresponding namespace `Symfony\Bundle\FrameworkBundle\Controller\Controller` is used. Instead of `Symfony\Bundle\FrameworkBundle\Controller\AbstractController`._
 
 #### Groups [`@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\ExtendController](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ExtendController.php)
+- Test class: [App\Tests\Rule\ExtendControllerTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/ExtendControllerTest.php)
 
 ## `extension_xlf_instead_of_xliff`
 
@@ -507,6 +670,11 @@ messages.xlf
 ```rst
 messages.xliff
 ```
+
+#### References
+
+- Rule class: [App\Rule\ExtensionXlfInsteadOfXliff](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ExtensionXlfInsteadOfXliff.php)
+- Test class: [App\Tests\Rule\ExtensionXlfInsteadOfXliffTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/ExtensionXlfInsteadOfXliffTest.php)
 
 ## `filename_uses_dashes_only`
 
@@ -530,6 +698,11 @@ _custom-extensions.rst
 custom_extensions.rst
 ```
 
+#### References
+
+- Rule class: [App\Rule\FilenameUsesDashesOnly](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/FilenameUsesDashesOnly.php)
+- Test class: [App\Tests\Rule\FilenameUsesDashesOnlyTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/FilenameUsesDashesOnlyTest.php)
+
 ## `filename_uses_underscores_only`
 
   > _Ensures a filename uses only underscores (`_`)._
@@ -552,13 +725,28 @@ _custom_extensions.rst
 custom-extensions.rst
 ```
 
+#### References
+
+- Rule class: [App\Rule\FilenameUsesUnderscoresOnly](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/FilenameUsesUnderscoresOnly.php)
+- Test class: [App\Tests\Rule\FilenameUsesUnderscoresOnlyTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/FilenameUsesUnderscoresOnlyTest.php)
+
 ## `final_admin_classes`
 
 #### Groups [`@Sonata`]
 
+#### References
+
+- Rule class: [App\Rule\FinalAdminClasses](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/FinalAdminClasses.php)
+- Test class: [App\Tests\Rule\FinalAdminClassesTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/FinalAdminClassesTest.php)
+
 ## `final_admin_extension_classes`
 
 #### Groups [`@Sonata`]
+
+#### References
+
+- Rule class: [App\Rule\FinalAdminExtensionClasses](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/FinalAdminExtensionClasses.php)
+- Test class: [App\Tests\Rule\FinalAdminExtensionClassesTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/FinalAdminExtensionClassesTest.php)
 
 ## `forbidden_directives`
 
@@ -572,6 +760,11 @@ Name | Required | Allowed Types | Default
 --- | --- | --- | ---
 `directives` | `false` | `array` | `[]`
 
+#### References
+
+- Rule class: [App\Rule\ForbiddenDirectives](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ForbiddenDirectives.php)
+- Test class: [App\Tests\Rule\ForbiddenDirectivesTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/ForbiddenDirectivesTest.php)
+
 ## `indention`
 
 #### Groups [`@Experimental`]
@@ -582,9 +775,19 @@ Name | Required | Allowed Types | Default
 --- | --- | --- | ---
 `size` | `false` | `int` | `4`
 
+#### References
+
+- Rule class: [App\Rule\Indention](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/Indention.php)
+- Test class: [App\Tests\Rule\IndentionTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/IndentionTest.php)
+
 ## `kernel_instead_of_app_kernel`
 
 #### Groups [`@Sonata`]
+
+#### References
+
+- Rule class: [App\Rule\KernelInsteadOfAppKernel](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/KernelInsteadOfAppKernel.php)
+- Test class: [App\Tests\Rule\KernelInsteadOfAppKernelTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/KernelInsteadOfAppKernelTest.php)
 
 ## `line_length`
 
@@ -594,9 +797,18 @@ Name | Required | Allowed Types | Default
 --- | --- | --- | ---
 `max` | `false` | `int` | `80`
 
+#### References
+
+- Rule class: [App\Rule\LineLength](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/LineLength.php)
+- Test class: [App\Tests\Rule\LineLengthTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/LineLengthTest.php)
+
 ## `lowercase_as_in_use_statements`
 
 #### Groups [`@Sonata`, `@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\LowercaseAsInUseStatements](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/LowercaseAsInUseStatements.php)
 
 ## `max_blank_lines`
 
@@ -607,6 +819,11 @@ Name | Required | Allowed Types | Default
 Name | Required | Allowed Types | Default
 --- | --- | --- | ---
 `max` | `false` | `int` | `2`
+
+#### References
+
+- Rule class: [App\Rule\MaxBlankLines](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/MaxBlankLines.php)
+- Test class: [App\Tests\Rule\MaxBlankLinesTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/MaxBlankLinesTest.php)
 
 ## `max_colons`
 
@@ -626,17 +843,35 @@ temp::
 temp:::
 ```
 
+#### References
+
+- Rule class: [App\Rule\MaxColons](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/MaxColons.php)
+- Test class: [App\Tests\Rule\MaxColonsTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/MaxColonsTest.php)
+
 ## `no_admin_yaml`
 
 #### Groups [`@Sonata`]
+
+#### References
+
+- Rule class: [App\Rule\NoAdminYaml](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoAdminYaml.php)
+- Test class: [App\Tests\Rule\NoAdminYamlTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoAdminYamlTest.php)
 
 ## `no_app_bundle`
 
 #### Groups [`@Sonata`]
 
+#### References
+
+- Rule class: [App\Rule\NoAppBundle](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoAppBundle.php)
+
 ## `no_app_console`
 
 #### Groups [`@Sonata`, `@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\NoAppConsole](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoAppConsole.php)
 
 ## `no_attribute_redundant_parenthesis`
 
@@ -660,6 +895,11 @@ temp:::
 #[Bar()]
 ```
 
+#### References
+
+- Rule class: [App\Rule\NoAttributeRedundantParenthesis](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoAttributeRedundantParenthesis.php)
+- Test class: [App\Tests\Rule\NoAttributeRedundantParenthesisTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoAttributeRedundantParenthesisTest.php)
+
 ## `no_bash_prompt`
 
   > _Ensure no bash prompt `$` is used before commands in `bash`, `shell` or `terminal` code blocks._
@@ -678,23 +918,53 @@ bin/console list
 $ bin/console list
 ```
 
+#### References
+
+- Rule class: [App\Rule\NoBashPrompt](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoBashPrompt.php)
+- Test class: [App\Tests\Rule\NoBashPromptTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoBashPromptTest.php)
+
 ## `no_blank_line_after_filepath_in_code_block`
+
+#### References
+
+- Rule class: [App\Rule\NoBlankLineAfterFilepathInCodeBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoBlankLineAfterFilepathInCodeBlock.php)
+- Test class: [App\Tests\Rule\NoBlankLineAfterFilepathInCodeBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoBlankLineAfterFilepathInCodeBlockTest.php)
 
 ## `no_blank_line_after_filepath_in_php_code_block`
 
 #### Groups [`@Symfony`]
 
+#### References
+
+- Rule class: [App\Rule\NoBlankLineAfterFilepathInPhpCodeBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoBlankLineAfterFilepathInPhpCodeBlock.php)
+- Test class: [App\Tests\Rule\NoBlankLineAfterFilepathInPhpCodeBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoBlankLineAfterFilepathInPhpCodeBlockTest.php)
+
 ## `no_blank_line_after_filepath_in_twig_code_block`
 
 #### Groups [`@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\NoBlankLineAfterFilepathInTwigCodeBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoBlankLineAfterFilepathInTwigCodeBlock.php)
+- Test class: [App\Tests\Rule\NoBlankLineAfterFilepathInTwigCodeBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoBlankLineAfterFilepathInTwigCodeBlockTest.php)
 
 ## `no_blank_line_after_filepath_in_xml_code_block`
 
 #### Groups [`@Symfony`]
 
+#### References
+
+- Rule class: [App\Rule\NoBlankLineAfterFilepathInXmlCodeBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoBlankLineAfterFilepathInXmlCodeBlock.php)
+- Test class: [App\Tests\Rule\NoBlankLineAfterFilepathInXmlCodeBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoBlankLineAfterFilepathInXmlCodeBlockTest.php)
+
 ## `no_blank_line_after_filepath_in_yaml_code_block`
 
 #### Groups [`@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\NoBlankLineAfterFilepathInYamlCodeBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoBlankLineAfterFilepathInYamlCodeBlock.php)
+- Test class: [App\Tests\Rule\NoBlankLineAfterFilepathInYamlCodeBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoBlankLineAfterFilepathInYamlCodeBlockTest.php)
 
 ## `no_brackets_in_method_directive`
 
@@ -714,6 +984,11 @@ $ bin/console list
 :method:`Symfony\\Component\\OptionsResolver\\Options::offsetGet()`
 ```
 
+#### References
+
+- Rule class: [App\Rule\NoBracketsInMethodDirective](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoBracketsInMethodDirective.php)
+- Test class: [App\Tests\Rule\NoBracketsInMethodDirectiveTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoBracketsInMethodDirectiveTest.php)
+
 ## `no_broken_ref_directive`
 
   > _Ensure only valid :ref: directives._
@@ -732,17 +1007,35 @@ See this :ref:`Foo`
 See this ref:`Foo`
 ```
 
+#### References
+
+- Rule class: [App\Rule\NoBrokenRefDirective](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoBrokenRefDirective.php)
+- Test class: [App\Tests\Rule\NoBrokenRefDirectiveTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoBrokenRefDirectiveTest.php)
+
 ## `no_composer_phar`
 
 #### Groups [`@Sonata`]
+
+#### References
+
+- Rule class: [App\Rule\NoComposerPhar](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoComposerPhar.php)
 
 ## `no_composer_req`
 
 #### Groups [`@Symfony`]
 
+#### References
+
+- Rule class: [App\Rule\NoComposerReq](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoComposerReq.php)
+- Test class: [App\Tests\Rule\NoComposerReqTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoComposerReqTest.php)
+
 ## `no_config_yaml`
 
 #### Groups [`@Sonata`, `@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\NoConfigYaml](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoConfigYaml.php)
 
 ## `no_contraction`
 
@@ -774,17 +1067,32 @@ It is an example
 It's an example
 ```
 
+#### References
+
+- Rule class: [App\Rule\NoContraction](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoContraction.php)
+- Test class: [App\Tests\Rule\NoContractionTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoContractionTest.php)
+
 ## `no_directive_after_shorthand`
 
   > _Ensure that no directive follows the shorthand `::`. This could lead to broken markup._
 
 #### Groups [`@Sonata`, `@Symfony`]
 
+#### References
+
+- Rule class: [App\Rule\NoDirectiveAfterShorthand](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoDirectiveAfterShorthand.php)
+- Test class: [App\Tests\Rule\NoDirectiveAfterShorthandTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoDirectiveAfterShorthandTest.php)
+
 ## `no_duplicate_use_statements`
 
   > _Ensure there is not same use statement twice_
 
 #### Groups [`@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\NoDuplicateUseStatements](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoDuplicateUseStatements.php)
+- Test class: [App\Tests\Rule\NoDuplicateUseStatementsTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoDuplicateUseStatementsTest.php)
 
 ## `no_empty_literals`
 
@@ -804,9 +1112,19 @@ Please use ``foo``...
 Please use ````...
 ```
 
+#### References
+
+- Rule class: [App\Rule\NoEmptyLiterals](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoEmptyLiterals.php)
+- Test class: [App\Tests\Rule\NoEmptyLiteralsTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoEmptyLiteralsTest.php)
+
 ## `no_explicit_use_of_code_block_php`
 
 #### Groups [`@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\NoExplicitUseOfCodeBlockPhp](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoExplicitUseOfCodeBlockPhp.php)
+- Test class: [App\Tests\Rule\NoExplicitUseOfCodeBlockPhpTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoExplicitUseOfCodeBlockPhpTest.php)
 
 ## `no_footnotes`
 
@@ -820,9 +1138,19 @@ Please use ````...
 .. [5] A numerical footnote. Note
 ```
 
+#### References
+
+- Rule class: [App\Rule\NoFootnotes](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoFootnotes.php)
+- Test class: [App\Tests\Rule\NoFootnotesTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoFootnotesTest.php)
+
 ## `no_inheritdoc_in_code_examples`
 
 #### Groups [`@Sonata`, `@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\NoInheritdocInCodeExamples](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoInheritdocInCodeExamples.php)
+- Test class: [App\Tests\Rule\NoInheritdocInCodeExamplesTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoInheritdocInCodeExamplesTest.php)
 
 ## `no_merge_conflict`
 
@@ -830,13 +1158,28 @@ Please use ````...
 
 #### Groups [`@Symfony`]
 
+#### References
+
+- Rule class: [App\Rule\NoMergeConflict](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoMergeConflict.php)
+- Test class: [App\Tests\Rule\NoMergeConflictTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoMergeConflictTest.php)
+
 ## `no_namespace_after_use_statements`
 
 #### Groups [`@Sonata`, `@Symfony`]
 
+#### References
+
+- Rule class: [App\Rule\NoNamespaceAfterUseStatements](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoNamespaceAfterUseStatements.php)
+- Test class: [App\Tests\Rule\NoNamespaceAfterUseStatementsTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoNamespaceAfterUseStatementsTest.php)
+
 ## `no_php_open_tag_in_code_block_php_directive`
 
 #### Groups [`@Sonata`, `@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\NoPhpOpenTagInCodeBlockPhpDirective](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoPhpOpenTagInCodeBlockPhpDirective.php)
+- Test class: [App\Tests\Rule\NoPhpOpenTagInCodeBlockPhpDirectiveTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoPhpOpenTagInCodeBlockPhpDirectiveTest.php)
 
 ## `no_php_prefix_before_bin_console`
 
@@ -856,13 +1199,28 @@ bin/console list
 php bin/console list
 ```
 
+#### References
+
+- Rule class: [App\Rule\NoPhpPrefixBeforeBinConsole](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoPhpPrefixBeforeBinConsole.php)
+- Test class: [App\Tests\Rule\NoPhpPrefixBeforeBinConsoleTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoPhpPrefixBeforeBinConsoleTest.php)
+
 ## `no_php_prefix_before_composer`
 
 #### Groups [`@Sonata`]
 
+#### References
+
+- Rule class: [App\Rule\NoPhpPrefixBeforeComposer](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoPhpPrefixBeforeComposer.php)
+- Test class: [App\Tests\Rule\NoPhpPrefixBeforeComposerTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoPhpPrefixBeforeComposerTest.php)
+
 ## `no_space_before_self_xml_closing_tag`
 
 #### Groups [`@Sonata`]
+
+#### References
+
+- Rule class: [App\Rule\NoSpaceBeforeSelfXmlClosingTag](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoSpaceBeforeSelfXmlClosingTag.php)
+- Test class: [App\Tests\Rule\NoSpaceBeforeSelfXmlClosingTagTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoSpaceBeforeSelfXmlClosingTagTest.php)
 
 ## `no_typographic_quotes`
 
@@ -882,6 +1240,11 @@ Lorem 'ipsum' dolor "sit amet"
 Lorem ‘ipsum’ dolor “sit amet”
 ```
 
+#### References
+
+- Rule class: [App\Rule\NoTypographicQuotes](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoTypographicQuotes.php)
+- Test class: [App\Tests\Rule\NoTypographicQuotesTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoTypographicQuotesTest.php)
+
 ## `non_static_phpunit_assertions`
 
   > _Use `$this->assert*` over static calls._
@@ -899,6 +1262,11 @@ $this->assertTrue($foo);
 ```rst
 self::assertTrue($foo);
 ```
+
+#### References
+
+- Rule class: [App\Rule\NonStaticPhpunitAssertions](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NonStaticPhpunitAssertions.php)
+- Test class: [App\Tests\Rule\NonStaticPhpunitAssertionsTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NonStaticPhpunitAssertionsTest.php)
 
 ## `only_backslashes_in_namespace_in_php_code_block`
 
@@ -918,6 +1286,11 @@ namespace Foo\Bar;
 namespace Foo/Bar;
 ```
 
+#### References
+
+- Rule class: [App\Rule\OnlyBackslashesInNamespaceInPhpCodeBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/OnlyBackslashesInNamespaceInPhpCodeBlock.php)
+- Test class: [App\Tests\Rule\OnlyBackslashesInNamespaceInPhpCodeBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/OnlyBackslashesInNamespaceInPhpCodeBlockTest.php)
+
 ## `only_backslashes_in_use_statements_in_php_code_block`
 
   > _A use statement in a PHP code-block should only contain backslashes._
@@ -936,11 +1309,26 @@ use Foo\Bar;
 use Foo/Bar;
 ```
 
+#### References
+
+- Rule class: [App\Rule\OnlyBackslashesInUseStatementsInPhpCodeBlock](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlock.php)
+- Test class: [App\Tests\Rule\OnlyBackslashesInUseStatementsInPhpCodeBlockTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlockTest.php)
+
 ## `ordered_use_statements`
 
 #### Groups [`@Sonata`, `@Symfony`]
 
+#### References
+
+- Rule class: [App\Rule\OrderedUseStatements](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/OrderedUseStatements.php)
+- Test class: [App\Tests\Rule\OrderedUseStatementsTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/OrderedUseStatementsTest.php)
+
 ## `php_open_tag_in_code_block_php_directive`
+
+#### References
+
+- Rule class: [App\Rule\PhpOpenTagInCodeBlockPhpDirective](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/PhpOpenTagInCodeBlockPhpDirective.php)
+- Test class: [App\Tests\Rule\PhpOpenTagInCodeBlockPhpDirectiveTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/PhpOpenTagInCodeBlockPhpDirectiveTest.php)
 
 ## `php_prefix_before_bin_console`
 
@@ -960,6 +1348,11 @@ php bin/console list
 bin/console list
 ```
 
+#### References
+
+- Rule class: [App\Rule\PhpPrefixBeforeBinConsole](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/PhpPrefixBeforeBinConsole.php)
+- Test class: [App\Tests\Rule\PhpPrefixBeforeBinConsoleTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/PhpPrefixBeforeBinConsoleTest.php)
+
 ## `remove_trailing_whitespace`
 
   > _Make sure there is not trailing whitespace._
@@ -978,6 +1371,11 @@ Valid sentence
 Invalid sentence 
 ```
 
+#### References
+
+- Rule class: [App\Rule\RemoveTrailingWhitespace](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/RemoveTrailingWhitespace.php)
+- Test class: [App\Tests\Rule\RemoveTrailingWhitespaceTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/RemoveTrailingWhitespaceTest.php)
+
 ## `replace_code_block_types`
 
   > _Propose alternatives for disallowed code block types._
@@ -991,6 +1389,10 @@ Pattern | Message
 `jinja` | Please do not use type "jinja" for code-block, use "twig" instead
 `html+jinja` | Please do not use type "html+jinja" for code-block, use "html+twig" instead
 `js` | Please do not use type "js" for code-block, use "javascript" instead
+
+#### References
+
+- Rule class: [App\Rule\ReplaceCodeBlockTypes](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ReplaceCodeBlockTypes.php)
 
 ## `replacement`
 
@@ -1023,11 +1425,26 @@ Pattern | Message
 `/PHPdoc/` | Please replace "%s" with "PHPDoc"
 `/eg\./` | Please replace "%s" with "e.g."
 
+#### References
+
+- Rule class: [App\Rule\Replacement](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/Replacement.php)
+- Test class: [App\Tests\Rule\ReplacementTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/ReplacementTest.php)
+
 ## `short_array_syntax`
 
 #### Groups [`@Sonata`]
 
+#### References
+
+- Rule class: [App\Rule\ShortArraySyntax](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ShortArraySyntax.php)
+- Test class: [App\Tests\Rule\ShortArraySyntaxTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/ShortArraySyntaxTest.php)
+
 ## `space_before_self_xml_closing_tag`
+
+#### References
+
+- Rule class: [App\Rule\SpaceBeforeSelfXmlClosingTag](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/SpaceBeforeSelfXmlClosingTag.php)
+- Test class: [App\Tests\Rule\SpaceBeforeSelfXmlClosingTagTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/SpaceBeforeSelfXmlClosingTagTest.php)
 
 ## `space_between_label_and_link_in_doc`
 
@@ -1047,6 +1464,11 @@ Pattern | Message
 :doc:`File</reference/constraints/File>`
 ```
 
+#### References
+
+- Rule class: [App\Rule\SpaceBetweenLabelAndLinkInDoc](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/SpaceBetweenLabelAndLinkInDoc.php)
+- Test class: [App\Tests\Rule\SpaceBetweenLabelAndLinkInDocTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/SpaceBetweenLabelAndLinkInDocTest.php)
+
 ## `space_between_label_and_link_in_ref`
 
   > _Ensure a space between label and link in :ref: directive._
@@ -1065,6 +1487,11 @@ Pattern | Message
 :ref:`receiving them via a worker<messenger-worker>`
 ```
 
+#### References
+
+- Rule class: [App\Rule\SpaceBetweenLabelAndLinkInRef](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/SpaceBetweenLabelAndLinkInRef.php)
+- Test class: [App\Tests\Rule\SpaceBetweenLabelAndLinkInRefTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/SpaceBetweenLabelAndLinkInRefTest.php)
+
 ## `string_replacement`
 
 #### Groups [`@Symfony`]
@@ -1076,7 +1503,17 @@ Pattern | Message
 `**type**: ``int``` | Please replace "%s" with "**type**: ``integer``"
 `**type**: ``bool``` | Please replace "%s" with "**type**: ``boolean``"
 
+#### References
+
+- Rule class: [App\Rule\StringReplacement](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/StringReplacement.php)
+- Test class: [App\Tests\Rule\StringReplacementTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/StringReplacementTest.php)
+
 ## `title_underline_length_must_match_title_length`
+
+#### References
+
+- Rule class: [App\Rule\TitleUnderlineLengthMustMatchTitleLength](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/TitleUnderlineLengthMustMatchTitleLength.php)
+- Test class: [App\Tests\Rule\TitleUnderlineLengthMustMatchTitleLengthTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/TitleUnderlineLengthMustMatchTitleLengthTest.php)
 
 ## `typo`
 
@@ -1108,19 +1545,39 @@ Pattern | Message
 `/contraint/i` | Typo in word "%s"
 `/instanciation/i` | Typo in word "%s", use "instantiation"
 
+#### References
+
+- Rule class: [App\Rule\Typo](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/Typo.php)
+- Test class: [App\Tests\Rule\TypoTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/TypoTest.php)
+
 ## `unused_links`
 
   > _Report all links which are defined, but not used in the file anymore._
 
 #### Groups [`@Sonata`, `@Symfony`]
 
+#### References
+
+- Rule class: [App\Rule\UnusedLinks](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/UnusedLinks.php)
+- Test class: [App\Tests\Rule\UnusedLinksTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/UnusedLinksTest.php)
+
 ## `use_deprecated_directive_instead_of_versionadded`
 
 #### Groups [`@Sonata`, `@Symfony`]
 
+#### References
+
+- Rule class: [App\Rule\UseDeprecatedDirectiveInsteadOfVersionadded](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/UseDeprecatedDirectiveInsteadOfVersionadded.php)
+- Test class: [App\Tests\Rule\UseDeprecatedDirectiveInsteadOfVersionaddedTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/UseDeprecatedDirectiveInsteadOfVersionaddedTest.php)
+
 ## `use_https_xsd_urls`
 
 #### Groups [`@Sonata`, `@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\UseHttpsXsdUrls](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/UseHttpsXsdUrls.php)
+- Test class: [App\Tests\Rule\UseHttpsXsdUrlsTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/UseHttpsXsdUrlsTest.php)
 
 ## `use_named_constructor_without_new_keyword_rule`
 
@@ -1137,6 +1594,11 @@ new Uuid()
 ```rst
 new Uuid::fromString()
 ```
+
+#### References
+
+- Rule class: [App\Rule\UseNamedConstructorWithoutNewKeywordRule](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/UseNamedConstructorWithoutNewKeywordRule.php)
+- Test class: [App\Tests\Rule\UseNamedConstructorWithoutNewKeywordRuleTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php)
 
 ## `valid_inline_highlighted_namespaces`
 
@@ -1164,9 +1626,18 @@ new Uuid::fromString()
 `App\Entity\Foo`
 ```
 
+#### References
+
+- Rule class: [App\Rule\ValidInlineHighlightedNamespaces](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ValidInlineHighlightedNamespaces.php)
+- Test class: [App\Tests\Rule\ValidInlineHighlightedNamespacesTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/ValidInlineHighlightedNamespacesTest.php)
+
 ## `valid_use_statements`
 
 #### Groups [`@Sonata`, `@Symfony`]
+
+#### References
+
+- Rule class: [App\Rule\ValidUseStatements](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ValidUseStatements.php)
 
 ## `versionadded_directive_major_version`
 
@@ -1178,6 +1649,11 @@ Name | Required
 --- | ---
 `major_version` | `true` | `int`
 
+#### References
+
+- Rule class: [App\Rule\VersionaddedDirectiveMajorVersion](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/VersionaddedDirectiveMajorVersion.php)
+- Test class: [App\Tests\Rule\VersionaddedDirectiveMajorVersionTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/VersionaddedDirectiveMajorVersionTest.php)
+
 ## `versionadded_directive_min_version`
 
 #### Groups [`@Symfony`]
@@ -1187,6 +1663,11 @@ Name | Required
 Name | Required
 --- | ---
 `min_version` | `true` | `string`
+
+#### References
+
+- Rule class: [App\Rule\VersionaddedDirectiveMinVersion](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/VersionaddedDirectiveMinVersion.php)
+- Test class: [App\Tests\Rule\VersionaddedDirectiveMinVersionTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/VersionaddedDirectiveMinVersionTest.php)
 
 ## `versionadded_directive_should_have_version`
 
@@ -1209,6 +1690,11 @@ Name | Required
 ```rst
 .. versionadded:: foo-bar
 ```
+
+#### References
+
+- Rule class: [App\Rule\VersionaddedDirectiveShouldHaveVersion](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/VersionaddedDirectiveShouldHaveVersion.php)
+- Test class: [App\Tests\Rule\VersionaddedDirectiveShouldHaveVersionTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/VersionaddedDirectiveShouldHaveVersionTest.php)
 
 ## `yaml_instead_of_yml_suffix`
 
@@ -1240,6 +1726,11 @@ Please add this to your services.yaml file.
 Please add this to your services.yml file.
 ```
 
+#### References
+
+- Rule class: [App\Rule\YamlInsteadOfYmlSuffix](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/YamlInsteadOfYmlSuffix.php)
+- Test class: [App\Tests\Rule\YamlInsteadOfYmlSuffixTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/YamlInsteadOfYmlSuffixTest.php)
+
 ## `yarn_dev_option_at_the_end`
 
   > _Make sure yarn `--dev` option for `add` command is used at the end._
@@ -1258,6 +1749,11 @@ yarn add jquery --dev
 yarn add --dev jquery
 ```
 
+#### References
+
+- Rule class: [App\Rule\YarnDevOptionAtTheEnd](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/YarnDevOptionAtTheEnd.php)
+- Test class: [App\Tests\Rule\YarnDevOptionAtTheEndTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/YarnDevOptionAtTheEndTest.php)
+
 ## `yarn_dev_option_not_at_the_end`
 
   > _Make sure yarn `--dev` option for `add` command is used at the end._
@@ -1273,4 +1769,9 @@ yarn add --dev jquery
 ```rst
 yarn add jquery --dev
 ```
+
+#### References
+
+- Rule class: [App\Rule\YarnDevOptionNotAtTheEnd](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/YarnDevOptionNotAtTheEnd.php)
+- Test class: [App\Tests\Rule\YarnDevOptionNotAtTheEndTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/YarnDevOptionNotAtTheEndTest.php)
 

--- a/src/Command/RulesCommand.php
+++ b/src/Command/RulesCommand.php
@@ -217,6 +217,8 @@ class RulesCommand extends Command
         if ($invalidExamples) {
             $this->renderExamples('##### Invalid Examples :-1:', $invalidExamples);
         }
+
+        $this->renderReferences($reflectionClass->getName(), $reflectionClass->getShortName());
     }
 
     /**
@@ -234,5 +236,54 @@ class RulesCommand extends Command
         }
 
         $this->io->newLine();
+    }
+
+    private function renderReferences(string $className, string $classShortName): void
+    {
+        $this->io->writeln('#### References');
+        $this->io->newLine();
+
+        $classPath = \sprintf(
+            'src/Rule/%s.php',
+            $classShortName,
+        );
+        $ruleLink = $this->renderGithubLink($className, $classPath);
+        $this->io->writeln(
+            \sprintf(
+                '- Rule class: %s',
+                $ruleLink,
+            ),
+        );
+
+        $testName = \sprintf(
+            'App\Tests\Rule\\%sTest',
+            $classShortName,
+        );
+
+        if (class_exists($testName)) {
+            $testPath = \sprintf(
+                'tests/Rule/%sTest.php',
+                $classShortName,
+            );
+            $testLink = $this->renderGithubLink($testName, $testPath);
+            $this->io->writeln(
+                \sprintf(
+                    '- Test class: %s',
+                    $testLink,
+                ),
+            );
+        }
+
+        $this->io->newLine();
+    }
+
+    private function renderGithubLink(string $name, string $relativeFilePath): string
+    {
+        return \sprintf(
+            '[%s](%s%s)',
+            $name,
+            'https://github.com/OskarStark/doctor-rst/blob/develop/',
+            $relativeFilePath,
+        );
     }
 }


### PR DESCRIPTION
Rules are configured in snake case in `.doctor-rst.yaml`. 
Sometime I want to see Rule logic, I must manually convert from snake to class name.
I propose to add  references in `docs.md` so class and test class



Inspired by php-cs-fixer

![image](https://github.com/user-attachments/assets/7b1b4e2f-5fcf-425a-86a0-40d0a2a33c1c)

https://cs.symfony.com/doc/rules/import/global_namespace_import.html