### PR TITLE
Improve an error message of a rule

### DIFF
--- a/src/Rule/NoTypographicQuotes.php
+++ b/src/Rule/NoTypographicQuotes.php
@@ -50,7 +50,7 @@ final class NoTypographicQuotes extends AbstractRule implements LineContentRule
 
         if ($lineContent->containsAny(['“', '”', '„', '“', '«', '»'])) {
             return Violation::from(
-                'Please use straight double quotes (" ... ") instead of curly quotes (“ ... ”)',
+                'Please use straight double quotes (" ... ") instead of typographic quotes (“ ... ”  „ ... “  « ... »)',
                 $filename,
                 $number + 1,
                 $line,

--- a/tests/Rule/NoTypographicQuotesTest.php
+++ b/tests/Rule/NoTypographicQuotesTest.php
@@ -47,7 +47,7 @@ final class NoTypographicQuotesTest extends UnitTestCase
             ],
             [
                 Violation::from(
-                    'Please use straight double quotes (" ... ") instead of curly quotes (“ ... ”)',
+                    'Please use straight double quotes (" ... ") instead of typographic quotes (“ ... ”  „ ... “  « ... »)',
                     'filename',
                     1,
                     'Lorem ipsum “dolor sit amet”, consectetur adipiscing elit.',
@@ -56,7 +56,7 @@ final class NoTypographicQuotesTest extends UnitTestCase
             ],
             [
                 Violation::from(
-                    'Please use straight double quotes (" ... ") instead of curly quotes (“ ... ”)',
+                    'Please use straight double quotes (" ... ") instead of typographic quotes (“ ... ”  „ ... “  « ... »)',
                     'filename',
                     1,
                     'Lorem ipsum „dolor sit amet“, consectetur adipiscing elit.',
@@ -65,7 +65,7 @@ final class NoTypographicQuotesTest extends UnitTestCase
             ],
             [
                 Violation::from(
-                    'Please use straight double quotes (" ... ") instead of curly quotes (“ ... ”)',
+                    'Please use straight double quotes (" ... ") instead of typographic quotes (“ ... ”  „ ... “  « ... »)',
                     'filename',
                     1,
                     'Lorem ipsum «dolor sit amet», consectetur adipiscing elit.',


### PR DESCRIPTION
Related to #2011, today someone using DOCtor-RST asked me why there was some RST issue reported if the content didn't contain curly quotes. The problem is that the content included a `«` character. So, let's be more explicit in the error message and let's list all the problematic characters.