### PR TITLE
Fix a false positive in Replacement rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1423,7 +1423,7 @@ Pattern | Message
 `/Performances/` | Please replace "%s" with "Performance"
 `/``'%kernel.debug%'``/` | Please replace "%s" with "``%%kernel.debug%%``"
 `/PHPdoc/` | Please replace "%s" with "PHPDoc"
-`/eg\./` | Please replace "%s" with "e.g."
+`/\beg\./` | Please replace "%s" with "e.g."
 
 #### References
 

--- a/src/Rule/Replacement.php
+++ b/src/Rule/Replacement.php
@@ -82,7 +82,7 @@ class Replacement extends CheckListRule implements LineContentRule
             '/Performances/' => 'Please replace "%s" with "Performance"',
             "/``'%kernel.debug%'``/" => 'Please replace "%s" with "``%%kernel.debug%%``"',
             '/PHPdoc/' => 'Please replace "%s" with "PHPDoc"',
-            '/eg\./' => 'Please replace "%s" with "e.g."',
+            '/\beg\./' => 'Please replace "%s" with "e.g."',
         ];
     }
 }

--- a/tests/Rule/ReplacementTest.php
+++ b/tests/Rule/ReplacementTest.php
@@ -84,6 +84,8 @@ final class ReplacementTest extends UnitTestCase
             'Performance',
             '``%kernel.debug%``',
             'e.g.',
+            # 'eg. in the URL should not be reported as mispelling of `e.g.`
+            '.. _`FFmpeg package`: https://ffmpeg.org/',
             'PHPDoc',
             //            '# username is your full Gmail or Google Apps email address', // todo this should be supported by the regex
         ];


### PR DESCRIPTION
Here's the false positive in Symfony Docs:

https://github.com/symfony/symfony-docs/actions/runs/17758395162/job/50465485145?pr=21384#step:7:11