### PR TITLE
Remove redundant @var annotations in RstAnalyzer

### DIFF
--- a/src/Analyzer/RstAnalyzer.php
+++ b/src/Analyzer/RstAnalyzer.php
@@ -17,7 +17,6 @@ use App\Rule\FileContentRule;
 use App\Rule\FileInfoRule;
 use App\Rule\LineContentRule;
 use App\Rule\Rule;
-use App\Value\Line;
 use App\Value\Lines;
 use App\Value\ViolationInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -79,10 +78,6 @@ final class RstAnalyzer implements Analyzer
         /** @var LineContentRule[] $lineContentRules */
         $lineContentRules = array_filter($rules, static fn (Rule $rule): bool => $rule instanceof LineContentRule);
 
-        /**
-         * @var int  $no
-         * @var Line $line
-         */
         foreach ($lines->toIterator() as $no => $line) {
             $lineIsBlank = $line->isBlank();
 


### PR DESCRIPTION
## Summary
- Remove inline `@var` annotations for the foreach loop iterator in `RstAnalyzer::analyze()`
- Remove unused `App\Value\Line` import

The type information is already properly defined in `Lines::toIterator()` with the `@return \ArrayIterator<int, Line>` annotation, making the inline annotations redundant.

## Benefits
- Eliminates code duplication
- Centralizes type information in the method definition
- Maintains full type safety (verified with PHPStan)

## Test plan
- [x] PHPStan analysis passes with no errors
- [x] Type information is correctly inferred from the `toIterator()` return type