### PR TITLE
Refactor: Extract repeated ResetInterface checks into method

### DIFF
--- a/src/Analyzer/RstAnalyzer.php
+++ b/src/Analyzer/RstAnalyzer.php
@@ -71,9 +71,7 @@ final class RstAnalyzer implements Analyzer
                 $violations[] = $violation;
             }
 
-            if ($rule instanceof ResetInterface) {
-                $rule->reset();
-            }
+            $this->resetIfNeeded($rule);
         }
 
         /** @var LineContentRule[] $lineContentRules */
@@ -101,12 +99,17 @@ final class RstAnalyzer implements Analyzer
                     $violations[] = $violation;
                 }
 
-                if ($rule instanceof ResetInterface) {
-                    $rule->reset();
-                }
+                $this->resetIfNeeded($rule);
             }
         }
 
         return $violations;
+    }
+
+    private function resetIfNeeded(Rule $rule): void
+    {
+        if ($rule instanceof ResetInterface) {
+            $rule->reset();
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR extracts duplicate `instanceof ResetInterface` checks in `RstAnalyzer.php` into a private `resetIfNeeded()` method.

## Changes

- Added `resetIfNeeded()` private method to encapsulate the reset logic
- Replaced two duplicate `instanceof ResetInterface` checks (lines 74-76 and 104-106) with calls to the new method
- Improves code maintainability and reduces duplication

## Test Plan

- Existing tests should pass
- No functional changes, only refactoring