### PR TITLE
Improve PHPStan configuration and reduce baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,25 +1,13 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Parameter \#2 \$value of method Symfony\\Component\\DependencyInjection\\Container\:\:setParameter\(\) expects array\|bool\|float\|int\|string\|UnitEnum\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Application.php
-
-		-
-			message: '#^Parameter \#1 \$prefix of static method PHPUnit\\Framework\\Assert\:\:assertStringStartsWith\(\) expects non\-empty\-string, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/Rule/TypoTest.php
-
-		-
-			message: '#^Call to function method_exists\(\) with App\\Tests\\Util\\DirectiveTraitWrapper and ''in'' will always evaluate to true\.$#'
+			message: '#^Call to function method_exists\(\) with ''App\\\\Tests\\\\Util\\\\DirectiveTraitWrapper'' and ''in'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: tests/Traits/DirectiveTraitTest.php
 
 		-
-			message: '#^Call to function method_exists\(\) with App\\Tests\\Util\\ListItemTraitWrapper and ''isPartOfListItem'' will always evaluate to true\.$#'
+			message: '#^Call to function method_exists\(\) with ''App\\\\Tests\\\\Util\\\\ListItemTraitWrapper'' and ''isPartOfListItem'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: tests/Traits/ListTraitTest.php

--- a/src/Analyzer/RstAnalyzer.php
+++ b/src/Analyzer/RstAnalyzer.php
@@ -68,7 +68,7 @@ final class RstAnalyzer implements Analyzer
                 $violations[] = $violation;
             }
 
-            $this->resetIfNeeded($rule);
+            self::resetIfNeeded($rule);
         }
 
         $lineContentRules = RuleFilter::byType($rules, LineContentRule::class);
@@ -91,14 +91,14 @@ final class RstAnalyzer implements Analyzer
                     $violations[] = $violation;
                 }
 
-                $this->resetIfNeeded($rule);
+                self::resetIfNeeded($rule);
             }
         }
 
         return $violations;
     }
 
-    private function resetIfNeeded(Rule $rule): void
+    private static function resetIfNeeded(Rule $rule): void
     {
         if ($rule instanceof ResetInterface) {
             $rule->reset();

--- a/src/Application.php
+++ b/src/Application.php
@@ -63,10 +63,9 @@ class Application extends BaseApplication
         $fileLoader->load('services.php');
 
         if (false === $input->hasParameterOption('--no-cache')) {
-            $container->setParameter(
-                'cache.file',
-                $input->getParameterOption('--cache-file', getcwd().'/.doctor-rst.cache'),
-            );
+            $cacheFile = $input->getParameterOption('--cache-file', getcwd().'/.doctor-rst.cache');
+            \assert(\is_string($cacheFile));
+            $container->setParameter('cache.file', $cacheFile);
 
             $fileLoader->load('cache.php');
         }

--- a/tests/Analyzer/RuleFilterTest.php
+++ b/tests/Analyzer/RuleFilterTest.php
@@ -21,7 +21,6 @@ use App\Rule\Rule;
 use App\Tests\Fixtures\Rule\DummyFileContentRule;
 use App\Tests\Fixtures\Rule\DummyFileInfoRule;
 use App\Tests\Fixtures\Rule\DummyLineContentRule;
-use App\Tests\Fixtures\Rule\DummyRule;
 use App\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 

--- a/tests/Rule/TypoTest.php
+++ b/tests/Rule/TypoTest.php
@@ -52,7 +52,9 @@ final class TypoTest extends UnitTestCase
             self::assertEmpty($violations);
         } else {
             self::assertCount(1, $violations);
-            self::assertStringStartsWith($expected->message(), $violations[0]->message());
+            $expectedMessage = $expected->message();
+            \assert('' !== $expectedMessage);
+            self::assertStringStartsWith($expectedMessage, $violations[0]->message());
         }
     }
 

--- a/tests/Traits/DirectiveTraitTest.php
+++ b/tests/Traits/DirectiveTraitTest.php
@@ -36,7 +36,7 @@ final class DirectiveTraitTest extends UnitTestCase
     #[Test]
     public function methodExists(): void
     {
-        self::assertTrue(method_exists($this->traitWrapper, 'in'));
+        self::assertTrue(method_exists(DirectiveTraitWrapper::class, 'in'));
     }
 
     #[Test]

--- a/tests/Traits/ListTraitTest.php
+++ b/tests/Traits/ListTraitTest.php
@@ -34,7 +34,7 @@ final class ListTraitTest extends UnitTestCase
     #[Test]
     public function methodExists(): void
     {
-        self::assertTrue(method_exists($this->traitWrapper, 'isPartOfListItem'));
+        self::assertTrue(method_exists(ListItemTraitWrapper::class, 'isPartOfListItem'));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Reduced PHPStan baseline from 4 entries to 2 entries (50% reduction)
- Fixed type safety issues and improved code quality
- All tests pass (1,840 tests)

## Changes

### PHPStan Baseline Improvements
- **Fixed**: Type mismatch in `Application::buildContainer()` - added explicit type assertion for cache file parameter
- **Fixed**: Non-empty-string assertion in `TypoTest` to satisfy PHPStan strict typing
- **Reduced baseline**: From 4 entries down to 2 entries (only intentional test assertions remain)

### Code Quality Improvements
- Improved `method_exists()` calls in trait tests to use `::class` notation for better type safety
- Made `RstAnalyzer::resetIfNeeded()` static for better code organization  
- Removed unused import in `RuleFilterTest`

### Note on checkMissingIterableValueType
The `checkMissingIterableValueType` configuration option was removed in PHPStan 2.0. The project already correctly handles this with `identifier: missingType.iterableValue` in the ignore configuration, so no changes were needed.

## Verification
- ✅ PHPStan analysis passes with no errors
- ✅ All 1,840 tests pass
- ✅ No behavior changes, only type safety improvements

## Remaining Baseline Entries
The 2 remaining baseline entries are intentional test assertions that verify method existence in trait wrappers:
- `tests/Traits/DirectiveTraitTest.php` - validates `in` method exists
- `tests/Traits/ListTraitTest.php` - validates `isPartOfListItem` method exists

These are legitimate test patterns and should remain in the baseline.