### PR TITLE
Fix false positive for RST links in `UseDoubleBackticksForInlineLiterals`

### DIFF
--- a/src/Rule/UseDoubleBackticksForInlineLiterals.php
+++ b/src/Rule/UseDoubleBackticksForInlineLiterals.php
@@ -32,10 +32,11 @@ use App\Value\ViolationInterface;
 final class UseDoubleBackticksForInlineLiterals extends AbstractRule implements LineContentRule
 {
     /**
-     * Regex pattern to match single-backtick content that is NOT preceded by a role.
-     * This pattern captures text like `word` but not :role:`word`.
+     * Regex pattern to match single-backtick content that is NOT preceded by a role
+     * and NOT followed by an underscore (RST link).
+     * This pattern captures text like `word` but not :role:`word` or `link`_.
      */
-    private const string PATTERN = '/(?<!:)(?<!\w)`([^`\n]+)`(?!`)/';
+    private const string PATTERN = '/(?<!:)(?<!\w)`([^`\n]+)`(?!`)(?!_)/';
 
     public static function getGroups(): array
     {

--- a/tests/Rule/UseDoubleBackticksForInlineLiteralsTest.php
+++ b/tests/Rule/UseDoubleBackticksForInlineLiteralsTest.php
@@ -104,5 +104,20 @@ final class UseDoubleBackticksForInlineLiteralsTest extends AbstractLineContentR
             ),
             new RstSample('Create a table named `blog`.'),
         ];
+
+        yield 'valid - RST link with trailing underscore' => [
+            NullViolation::create(),
+            new RstSample('it by using the native PHP `reflection`_. This method is defined in the'),
+        ];
+
+        yield 'valid - RST link with trailing underscore at end of line' => [
+            NullViolation::create(),
+            new RstSample('See the `official documentation`_'),
+        ];
+
+        yield 'valid - RST anonymous link with double underscore' => [
+            NullViolation::create(),
+            new RstSample('Check the `example`__ for more details.'),
+        ];
     }
 }


### PR DESCRIPTION
## Summary

- Fix false positive where RST hyperlinks like `` `reflection`_ `` were incorrectly flagged as needing double backticks
- Update regex pattern to exclude backticks followed by underscore (RST link syntax)
- Add test cases for both named links (`link`_) and anonymous links (`link`__)

## Test plan

- [x] All existing tests pass
- [x] New test cases added for RST link syntax
- [x] PHPStan analysis passes