### PR TITLE
Fix false positive for text between RST links in UseDoubleBackticksForInlineLiterals

### DIFF
--- a/tests/Rule/UseDoubleBackticksForInlineLiteralsTest.php
+++ b/tests/Rule/UseDoubleBackticksForInlineLiteralsTest.php
@@ -142,5 +142,25 @@ final class UseDoubleBackticksForInlineLiteralsTest extends AbstractLineContentR
             NullViolation::create(),
             new RstSample(':ref:`Rendering forms <rendering-forms>` and :ref:`processing forms <processing-forms>`'),
         ];
+
+        yield 'valid - multiple RST links on same line' => [
+            NullViolation::create(),
+            new RstSample('Validates that a value is a valid `Universally unique identifier (UUID)`_ per `RFC 4122`_.'),
+        ];
+
+        yield 'valid - ref role followed by RST link' => [
+            NullViolation::create(),
+            new RstSample('* :ref:`Webpack Encore <frontend-webpack-encore>` is built with `Node.js`_'),
+        ];
+
+        yield 'valid - multiple RST links with or separator' => [
+            NullViolation::create(),
+            new RstSample('and `JSON Web Tokens (JWT)`_ or `SAML2 (XML structures)`_. Please refer to the'),
+        ];
+
+        yield 'valid - doc role followed by RST link' => [
+            NullViolation::create(),
+            new RstSample('and Because :doc:`the Form component </forms>` as well as `API Platform`_ internally'),
+        ];
     }
 }


### PR DESCRIPTION
## Summary

- Fixes false positives when multiple RST links or roles appear on the same line
- The regex was incorrectly matching text between backtick sequences as single-backtick literals

**Examples that were incorrectly flagged:**
- `` `Universally unique identifier (UUID)`_ per `RFC 4122`_. `` - matched `_ per ` 
- `` :ref:`Webpack Encore` is built with `Node.js`_ `` - matched ` is built with `
- `` `JSON Web Tokens (JWT)`_ or `SAML2 (XML structures)`_ `` - matched `_ or `
- `` :doc:`the Form component </forms>` as well as `API Platform`_ `` - matched ` as well as `

**Changes:**
1. Updated regex pattern to exclude content starting with underscore (text after RST link closings)
2. Added logic to skip content that starts AND ends with whitespace (text between backtick sequences)

## Test plan

- [x] Added test cases for all example patterns
- [x] All existing tests pass (1866 tests)