### PR TITLE
Fix false positive for RST link target definitions in `UseDoubleBackticksForInlineLiterals`

### DIFF
--- a/src/Rst/RstParser.php
+++ b/src/Rst/RstParser.php
@@ -214,7 +214,7 @@ class RstParser
 
     public static function isLinkDefinition(Line $line): bool
     {
-        return [] !== $line->raw()->match('/^\.\. _(`([^`]+)`|([^`]+)): (.*)$/');
+        return [] !== $line->raw()->match('/^\s*\.\. _(`([^`]+)`|([^`]+)): (.*)$/');
     }
 
     public static function isLinkUsage(string $string): bool

--- a/src/Rule/UseDoubleBackticksForInlineLiterals.php
+++ b/src/Rule/UseDoubleBackticksForInlineLiterals.php
@@ -74,6 +74,10 @@ final class UseDoubleBackticksForInlineLiterals extends AbstractRule implements 
             return NullViolation::create();
         }
 
+        if (RstParser::isLinkDefinition($line)) {
+            return NullViolation::create();
+        }
+
         // Match single-backtick patterns that are not part of a role or RST link
         if (preg_match_all(self::PATTERN, $rawLine, $matches, \PREG_SET_ORDER)) {
             foreach ($matches as $match) {

--- a/tests/Rst/RstParserTest.php
+++ b/tests/Rst/RstParserTest.php
@@ -138,6 +138,7 @@ final class RstParserTest extends UnitTestCase
         yield [true, '.. _`Symfony`: https://symfony.com'];
         yield [true, '.. _`APCu`: https://github.com/krakjoe/apcu'];
         yield [true, '.. _APCu: https://github.com/krakjoe/apcu'];
+        yield [true, '   .. _`Pimple`: https://github.com/silexphp/Pimple'];
 
         yield [false, '.. _APCu`: https://github.com/krakjoe/apcu'];
         yield [false, '.. _`APCu: https://github.com/krakjoe/apcu'];

--- a/tests/Rule/UseDoubleBackticksForInlineLiteralsTest.php
+++ b/tests/Rule/UseDoubleBackticksForInlineLiteralsTest.php
@@ -162,5 +162,15 @@ final class UseDoubleBackticksForInlineLiteralsTest extends AbstractLineContentR
             NullViolation::create(),
             new RstSample('and Because :doc:`the Form component </forms>` as well as `API Platform`_ internally'),
         ];
+
+        yield 'valid - RST link target definition with backticks' => [
+            NullViolation::create(),
+            new RstSample('.. _`same-origin`: https://en.wikipedia.org/wiki/Same-origin_policy'),
+        ];
+
+        yield 'valid - indented RST link target definition with backticks' => [
+            NullViolation::create(),
+            new RstSample('   .. _`Pimple`: https://github.com/silexphp/Pimple'),
+        ];
     }
 }


### PR DESCRIPTION
RST link target definitions using backticks (e.g., `.. _`same-origin`: URL`) were incorrectly flagged as needing double backticks. This is valid RST syntax for defining a named hyperlink target with special characters.