### PR TITLE
Fix false positive for RST internal anchors without URLs

### DIFF
--- a/src/Rule/UseDoubleBackticksForInlineLiterals.php
+++ b/src/Rule/UseDoubleBackticksForInlineLiterals.php
@@ -74,7 +74,7 @@ final class UseDoubleBackticksForInlineLiterals extends AbstractRule implements 
             return NullViolation::create();
         }
 
-        if (RstParser::isLinkDefinition($line)) {
+        if (RstParser::isLinkDefinition($line) || RstParser::isAnchor($line)) {
             return NullViolation::create();
         }
 

--- a/tests/Rule/UseDoubleBackticksForInlineLiteralsTest.php
+++ b/tests/Rule/UseDoubleBackticksForInlineLiteralsTest.php
@@ -172,5 +172,15 @@ final class UseDoubleBackticksForInlineLiteralsTest extends AbstractLineContentR
             NullViolation::create(),
             new RstSample('   .. _`Pimple`: https://github.com/silexphp/Pimple'),
         ];
+
+        yield 'valid - RST internal anchor without URL' => [
+            NullViolation::create(),
+            new RstSample('.. _`upgrade-minor-symfony-composer`:'),
+        ];
+
+        yield 'valid - RST internal anchor without backticks or URL' => [
+            NullViolation::create(),
+            new RstSample('.. _upgrade-minor-symfony-code:'),
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- Skip RST internal anchors (like `.. _`name`:`) in `UseDoubleBackticksForInlineLiterals` rule
- Uses existing `isAnchor` method to detect anchors without URLs

## Test plan
- [x] Added test cases for internal anchors with and without backticks
- [x] All existing tests pass (1877 tests)