### PR TITLE
Fix false positive for RST roles between doc links in UseDoubleBackticksForInlineLiterals

### DIFF
--- a/src/Rule/UseDoubleBackticksForInlineLiterals.php
+++ b/src/Rule/UseDoubleBackticksForInlineLiterals.php
@@ -42,12 +42,14 @@ final class UseDoubleBackticksForInlineLiterals extends AbstractRule implements 
      * - Not preceded by :rolename (RST role like :ref:, :doc:, etc.)
      * - Content starts and ends with non-whitespace (valid inline literal format)
      * - Not followed by _ (RST link reference)
+     * - Content doesn't start with , ; or _ (to avoid matching text between RST links)
+     * - Content doesn't end with :[a-z] (to avoid matching text followed by RST roles)
      *
-     * The pattern ([^\s`][^`]*[^\s`]|\S) matches either:
+     * The inner pattern ([^\s`][^`]*[^\s`]|\S) matches either:
      * - Multi-char content: starts non-whitespace, any middle chars, ends non-whitespace
      * - Single char: just one non-whitespace character
      */
-    private const string PATTERN = '/(?<!:)(?<![a-z])`([^\s`][^`]*[^\s`]|\S)`(?!_)/i';
+    private const string PATTERN = '/(?<!:)(?<![a-z])`((?![,;_])([^\s`][^`]*[^\s`]|\S)(?<!:[a-z]))`(?!_)/i';
 
     public static function getGroups(): array
     {

--- a/tests/Rule/UseDoubleBackticksForInlineLiteralsTest.php
+++ b/tests/Rule/UseDoubleBackticksForInlineLiteralsTest.php
@@ -182,5 +182,30 @@ final class UseDoubleBackticksForInlineLiteralsTest extends AbstractLineContentR
             NullViolation::create(),
             new RstSample('.. _upgrade-minor-symfony-code:'),
         ];
+
+        yield 'valid - doc role followed by comma and another doc role' => [
+            NullViolation::create(),
+            new RstSample(':doc:`routing </routing>`, or rendering :doc:`controllers </controller>`;'),
+        ];
+
+        yield 'valid - RST link followed by comma and doc role' => [
+            NullViolation::create(),
+            new RstSample('`Templating`_, :doc:`Security </security>`, :doc:`Form </components/form>`,'),
+        ];
+
+        yield 'valid - multiple doc roles with commas' => [
+            NullViolation::create(),
+            new RstSample('(:doc:`Apcu </components/cache/adapters/apcu_adapter>`, :doc:`Memcached </components/cache/adapters/memcached_adapter>`,'),
+        ];
+
+        yield 'valid - doc role followed by semicolon and another doc role' => [
+            NullViolation::create(),
+            new RstSample(':doc:`one </one>`; :doc:`two </two>`'),
+        ];
+
+        yield 'valid - RST link followed by text and class role' => [
+            NullViolation::create(),
+            new RstSample('Symfony comes with two minimalist `PSR-3`_ loggers: :class:`Symfony\\Component\\HttpKernel\\Log\\Logger`'),
+        ];
     }
 }


### PR DESCRIPTION
## Summary

- Fix false positive when text appears between RST links and RST roles (e.g., `:doc:`, `:class:`)
- The rule was incorrectly matching text like `, or rendering :doc:` or `_ loggers: :class:` as inline literals
- Updated regex pattern to exclude matches starting with `, ; _` or ending with `:[a-z]`

## Test plan

- [x] Added test cases for the reported false positive scenarios
- [x] All 30 tests pass
- [x] Verified existing valid violations are still caught