### PR TITLE
Make all rule classes final

### DIFF
--- a/src/Rule/AmericanEnglish.php
+++ b/src/Rule/AmericanEnglish.php
@@ -28,7 +28,7 @@ use App\Value\ViolationInterface;
 #[Description('Ensure only American English is used.')]
 #[InvalidExample('This is a nice behaviour...')]
 #[ValidExample('This is a nice behavior...')]
-class AmericanEnglish extends CheckListRule implements LineContentRule
+final class AmericanEnglish extends CheckListRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/ArgumentVariableMustMatchType.php
+++ b/src/Rule/ArgumentVariableMustMatchType.php
@@ -25,7 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @no-named-arguments
  */
 #[Description('Make sure argument variable name match for type')]
-class ArgumentVariableMustMatchType extends AbstractRule implements Configurable, LineContentRule
+final class ArgumentVariableMustMatchType extends AbstractRule implements Configurable, LineContentRule
 {
     use DirectiveTrait;
 

--- a/src/Rule/AvoidRepetetiveWords.php
+++ b/src/Rule/AvoidRepetetiveWords.php
@@ -34,7 +34,7 @@ use App\Value\ViolationInterface;
 #[Description('Make sure that a word is not used twice in a row.')]
 #[ValidExample('Please do not use it this way...')]
 #[InvalidExample('Please do not not use it this way...')]
-class AvoidRepetetiveWords extends AbstractRule implements LineContentRule
+final class AvoidRepetetiveWords extends AbstractRule implements LineContentRule
 {
     use DirectiveTrait;
 

--- a/src/Rule/BeKindToNewcomers.php
+++ b/src/Rule/BeKindToNewcomers.php
@@ -24,7 +24,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Do not use belittling words!')]
-class BeKindToNewcomers extends CheckListRule implements LineContentRule
+final class BeKindToNewcomers extends CheckListRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/BlankLineAfterAnchor.php
+++ b/src/Rule/BlankLineAfterAnchor.php
@@ -25,7 +25,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Make sure you have a blank line after anchor (`.. anchor:`).')]
-class BlankLineAfterAnchor extends AbstractRule implements LineContentRule
+final class BlankLineAfterAnchor extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/BlankLineAfterColon.php
+++ b/src/Rule/BlankLineAfterColon.php
@@ -26,7 +26,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Make sure you have a blank line after a sentence which ends with a colon (`:`).')]
-class BlankLineAfterColon extends AbstractRule implements LineContentRule
+final class BlankLineAfterColon extends AbstractRule implements LineContentRule
 {
     use DirectiveTrait;
 

--- a/src/Rule/BlankLineAfterDirective.php
+++ b/src/Rule/BlankLineAfterDirective.php
@@ -25,7 +25,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Make sure you have a blank line after each directive.')]
-class BlankLineAfterDirective extends AbstractRule implements LineContentRule
+final class BlankLineAfterDirective extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/BlankLineAfterFilepathInCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInCodeBlock.php
@@ -25,7 +25,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Make sure you have a blank line after a filepath in a code block. This rule respects PHP, YAML, XML and Twig.')]
-class BlankLineAfterFilepathInCodeBlock extends AbstractRule implements LineContentRule
+final class BlankLineAfterFilepathInCodeBlock extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/BlankLineAfterFilepathInPhpCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInPhpCodeBlock.php
@@ -25,7 +25,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Make sure you have a blank line after a filepath in a PHP code block.')]
-class BlankLineAfterFilepathInPhpCodeBlock extends AbstractRule implements LineContentRule
+final class BlankLineAfterFilepathInPhpCodeBlock extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {

--- a/src/Rule/BlankLineAfterFilepathInTwigCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInTwigCodeBlock.php
@@ -25,7 +25,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Make sure you have a blank line after a filepath in a Twig code block.')]
-class BlankLineAfterFilepathInTwigCodeBlock extends AbstractRule implements LineContentRule
+final class BlankLineAfterFilepathInTwigCodeBlock extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {

--- a/src/Rule/BlankLineAfterFilepathInXmlCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInXmlCodeBlock.php
@@ -25,7 +25,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Make sure you have a blank line after a filepath in a XML code block.')]
-class BlankLineAfterFilepathInXmlCodeBlock extends AbstractRule implements LineContentRule
+final class BlankLineAfterFilepathInXmlCodeBlock extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {

--- a/src/Rule/BlankLineAfterFilepathInYamlCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInYamlCodeBlock.php
@@ -25,7 +25,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Make sure you have a blank line after a filepath in a YAML code block.')]
-class BlankLineAfterFilepathInYamlCodeBlock extends AbstractRule implements LineContentRule
+final class BlankLineAfterFilepathInYamlCodeBlock extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {

--- a/src/Rule/BlankLineBeforeDirective.php
+++ b/src/Rule/BlankLineBeforeDirective.php
@@ -25,7 +25,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Make sure you have a blank line before each directive.')]
-class BlankLineBeforeDirective extends AbstractRule implements LineContentRule
+final class BlankLineBeforeDirective extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/ComposerDevOptionAtTheEnd.php
+++ b/src/Rule/ComposerDevOptionAtTheEnd.php
@@ -28,7 +28,7 @@ use App\Value\ViolationInterface;
 #[Description('Make sure Composer `--dev` option for `require` command is used at the end.')]
 #[InvalidExample('composer require --dev symfony/var-dumper')]
 #[ValidExample('composer require symfony/var-dumper --dev')]
-class ComposerDevOptionAtTheEnd extends AbstractRule implements LineContentRule
+final class ComposerDevOptionAtTheEnd extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/ComposerDevOptionNotAtTheEnd.php
+++ b/src/Rule/ComposerDevOptionNotAtTheEnd.php
@@ -28,7 +28,7 @@ use App\Value\ViolationInterface;
 #[Description('Make sure Composer `--dev` option for `require` command is not used at the end.')]
 #[InvalidExample('composer require symfony/var-dumper --dev')]
 #[ValidExample('composer require --dev symfony/var-dumper')]
-class ComposerDevOptionNotAtTheEnd extends AbstractRule implements LineContentRule
+final class ComposerDevOptionNotAtTheEnd extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/CorrectCodeBlockDirectiveBasedOnTheContent.php
+++ b/src/Rule/CorrectCodeBlockDirectiveBasedOnTheContent.php
@@ -23,7 +23,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class CorrectCodeBlockDirectiveBasedOnTheContent extends AbstractRule implements LineContentRule
+final class CorrectCodeBlockDirectiveBasedOnTheContent extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/DeprecatedDirectiveMajorVersion.php
+++ b/src/Rule/DeprecatedDirectiveMajorVersion.php
@@ -25,7 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @no-named-arguments
  */
-class DeprecatedDirectiveMajorVersion extends AbstractRule implements Configurable, LineContentRule
+final class DeprecatedDirectiveMajorVersion extends AbstractRule implements Configurable, LineContentRule
 {
     private int $majorVersion;
 

--- a/src/Rule/DeprecatedDirectiveMinVersion.php
+++ b/src/Rule/DeprecatedDirectiveMinVersion.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @no-named-arguments
  */
-class DeprecatedDirectiveMinVersion extends AbstractRule implements Configurable, LineContentRule
+final class DeprecatedDirectiveMinVersion extends AbstractRule implements Configurable, LineContentRule
 {
     private string $minVersion;
 

--- a/src/Rule/DeprecatedDirectiveShouldHaveVersion.php
+++ b/src/Rule/DeprecatedDirectiveShouldHaveVersion.php
@@ -31,7 +31,7 @@ use Composer\Semver\VersionParser;
 #[ValidExample('.. deprecated:: 3.4')]
 #[InvalidExample('.. deprecated::')]
 #[InvalidExample('.. deprecated:: foo-bar')]
-class DeprecatedDirectiveShouldHaveVersion extends AbstractRule implements LineContentRule
+final class DeprecatedDirectiveShouldHaveVersion extends AbstractRule implements LineContentRule
 {
     public function __construct(
         private readonly VersionParser $versionParser,

--- a/src/Rule/EnsureBashPromptBeforeComposerCommand.php
+++ b/src/Rule/EnsureBashPromptBeforeComposerCommand.php
@@ -30,7 +30,7 @@ use App\Value\ViolationInterface;
 #[Description('Make sure Composer command in a terminal/bash code block is prefixed with a $.')]
 #[InvalidExample('composer require symfony/var-dumper')]
 #[ValidExample('$ composer require symfony/var-dumper')]
-class EnsureBashPromptBeforeComposerCommand extends AbstractRule implements LineContentRule
+final class EnsureBashPromptBeforeComposerCommand extends AbstractRule implements LineContentRule
 {
     use DirectiveTrait;
 

--- a/src/Rule/EnsureExactlyOneSpaceBeforeDirectiveType.php
+++ b/src/Rule/EnsureExactlyOneSpaceBeforeDirectiveType.php
@@ -28,7 +28,7 @@ use App\Value\ViolationInterface;
 #[Description('Ensure exactly one space before directive type.')]
 #[InvalidExample('..  code-block:: php')]
 #[ValidExample('.. code-block:: php')]
-class EnsureExactlyOneSpaceBeforeDirectiveType extends AbstractRule implements LineContentRule
+final class EnsureExactlyOneSpaceBeforeDirectiveType extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink.php
+++ b/src/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink.php
@@ -29,7 +29,7 @@ use App\Value\ViolationInterface;
 #[Description('Ensure exactly one space between link definition and link.')]
 #[InvalidExample('.. _DOCtor-RST:     https://github.com/OskarStark/DOCtor-RST')]
 #[ValidExample('.. _DOCtor-RST: https://github.com/OskarStark/DOCtor-RST')]
-class EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink extends AbstractRule implements LineContentRule
+final class EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/EnsureExplicitNullableTypes.php
+++ b/src/Rule/EnsureExplicitNullableTypes.php
@@ -30,7 +30,7 @@ use App\Value\ViolationInterface;
 #[ValidExample('function foo(?string $bar = null)')]
 #[ValidExample('function foo(string|null $bar = null)')]
 #[InvalidExample('function foo(string $bar = null)')]
-class EnsureExplicitNullableTypes extends AbstractRule implements LineContentRule
+final class EnsureExplicitNullableTypes extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/EnsureGithubDirectiveStartWithPrefix.php
+++ b/src/Rule/EnsureGithubDirectiveStartWithPrefix.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @no-named-arguments
  */
-class EnsureGithubDirectiveStartWithPrefix extends AbstractRule implements Configurable, LineContentRule
+final class EnsureGithubDirectiveStartWithPrefix extends AbstractRule implements Configurable, LineContentRule
 {
     private string $prefix;
 

--- a/src/Rule/EnsureLinkBottom.php
+++ b/src/Rule/EnsureLinkBottom.php
@@ -25,7 +25,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Ensure link lines are at the bottom of the file.')]
-class EnsureLinkBottom extends AbstractRule implements LineContentRule
+final class EnsureLinkBottom extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/EnsureLinkDefinitionContainsValidUrl.php
+++ b/src/Rule/EnsureLinkDefinitionContainsValidUrl.php
@@ -30,7 +30,7 @@ use App\Value\ViolationInterface;
 #[Description('Ensure link definition contains valid link.')]
 #[InvalidExample('.. _DOCtor-RST: htt//github.com/OskarStark/DOCtor-RST')]
 #[ValidExample('.. _DOCtor-RST: https://github.com/OskarStark/DOCtor-RST')]
-class EnsureLinkDefinitionContainsValidUrl extends AbstractRule implements LineContentRule
+final class EnsureLinkDefinitionContainsValidUrl extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/EnsureOrderOfCodeBlocksInConfigurationBlock.php
+++ b/src/Rule/EnsureOrderOfCodeBlocksInConfigurationBlock.php
@@ -24,7 +24,7 @@ use Webmozart\Assert\Assert;
 /**
  * @no-named-arguments
  */
-class EnsureOrderOfCodeBlocksInConfigurationBlock extends AbstractRule implements LineContentRule
+final class EnsureOrderOfCodeBlocksInConfigurationBlock extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/EnsurePhpReferenceSyntax.php
+++ b/src/Rule/EnsurePhpReferenceSyntax.php
@@ -30,7 +30,7 @@ use function Symfony\Component\String\u;
 #[InvalidExample('The :class:`Symfony\\Component\\Notifier\\Transport`` class')]
 #[InvalidExample('The :class:`Symfony\\\\AI\\\\Platform\\PlatformInterface` class')]
 #[ValidExample('The :class:`Symfony\\Component\\Notifier\\Transport` class')]
-class EnsurePhpReferenceSyntax extends AbstractRule implements LineContentRule
+final class EnsurePhpReferenceSyntax extends AbstractRule implements LineContentRule
 {
     private const string PATTERN = '/:(class|method|namespace|phpclass|phpfunction|phpmethod):`([^`]+)`/';
 

--- a/src/Rule/ExtendAbstractAdmin.php
+++ b/src/Rule/ExtendAbstractAdmin.php
@@ -24,7 +24,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Ensure `AbstractAdmin` and the corresponding namespace `Sonata\\AdminBundle\\Admin\\AbstractAdmin` is used.')]
-class ExtendAbstractAdmin extends AbstractRule implements LineContentRule
+final class ExtendAbstractAdmin extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/ExtendAbstractController.php
+++ b/src/Rule/ExtendAbstractController.php
@@ -24,7 +24,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Ensure `AbstractController` and the corresponding namespace `Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController` is used. Instead of `Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller`.')]
-class ExtendAbstractController extends AbstractRule implements LineContentRule
+final class ExtendAbstractController extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/ExtendController.php
+++ b/src/Rule/ExtendController.php
@@ -24,7 +24,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Ensure `Controller` and the corresponding namespace `Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller` is used. Instead of `Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController`.')]
-class ExtendController extends AbstractRule implements LineContentRule
+final class ExtendController extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/ExtensionXlfInsteadOfXliff.php
+++ b/src/Rule/ExtensionXlfInsteadOfXliff.php
@@ -28,7 +28,7 @@ use App\Value\ViolationInterface;
 #[Description('Make sure to only use `.xlf` instead of `.xliff`.')]
 #[ValidExample('messages.xlf')]
 #[InvalidExample('messages.xliff')]
-class ExtensionXlfInsteadOfXliff extends AbstractRule implements LineContentRule
+final class ExtensionXlfInsteadOfXliff extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/FinalAdminClasses.php
+++ b/src/Rule/FinalAdminClasses.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class FinalAdminClasses extends AbstractRule implements LineContentRule
+final class FinalAdminClasses extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/FinalAdminExtensionClasses.php
+++ b/src/Rule/FinalAdminExtensionClasses.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class FinalAdminExtensionClasses extends AbstractRule implements LineContentRule
+final class FinalAdminExtensionClasses extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/ForbiddenDirectives.php
+++ b/src/Rule/ForbiddenDirectives.php
@@ -29,7 +29,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @no-named-arguments
  */
 #[Description('Make sure forbidden directives are not used')]
-class ForbiddenDirectives extends AbstractRule implements Configurable, LineContentRule
+final class ForbiddenDirectives extends AbstractRule implements Configurable, LineContentRule
 {
     use DirectiveTrait;
 

--- a/src/Rule/Indention.php
+++ b/src/Rule/Indention.php
@@ -29,7 +29,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @no-named-arguments
  */
-class Indention extends AbstractRule implements Configurable, LineContentRule
+final class Indention extends AbstractRule implements Configurable, LineContentRule
 {
     use DirectiveTrait;
     use ListTrait;

--- a/src/Rule/KernelInsteadOfAppKernel.php
+++ b/src/Rule/KernelInsteadOfAppKernel.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class KernelInsteadOfAppKernel extends AbstractRule implements LineContentRule
+final class KernelInsteadOfAppKernel extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/LineLength.php
+++ b/src/Rule/LineLength.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @no-named-arguments
  */
-class LineLength extends AbstractRule implements Configurable, LineContentRule
+final class LineLength extends AbstractRule implements Configurable, LineContentRule
 {
     private int $max;
 

--- a/src/Rule/LowercaseAsInUseStatements.php
+++ b/src/Rule/LowercaseAsInUseStatements.php
@@ -23,7 +23,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class LowercaseAsInUseStatements extends AbstractRule implements LineContentRule
+final class LowercaseAsInUseStatements extends AbstractRule implements LineContentRule
 {
     use DirectiveTrait;
 

--- a/src/Rule/MaxBlankLines.php
+++ b/src/Rule/MaxBlankLines.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @no-named-arguments
  */
-class MaxBlankLines extends AbstractRule implements Configurable, LineContentRule
+final class MaxBlankLines extends AbstractRule implements Configurable, LineContentRule
 {
     private int $max;
 

--- a/src/Rule/NoAdminYaml.php
+++ b/src/Rule/NoAdminYaml.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoAdminYaml extends AbstractRule implements LineContentRule
+final class NoAdminYaml extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoAppBundle.php
+++ b/src/Rule/NoAppBundle.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoAppBundle extends AbstractRule implements LineContentRule
+final class NoAppBundle extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoAppConsole.php
+++ b/src/Rule/NoAppConsole.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoAppConsole extends AbstractRule implements LineContentRule
+final class NoAppConsole extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoAttributeRedundantParenthesis.php
+++ b/src/Rule/NoAttributeRedundantParenthesis.php
@@ -29,7 +29,7 @@ use App\Value\ViolationInterface;
 #[InvalidExample('#[Bar()]')]
 #[ValidExample('#[Bar]')]
 #[ValidExample('#[Bar(\'foo\')]')]
-class NoAttributeRedundantParenthesis extends AbstractRule implements LineContentRule
+final class NoAttributeRedundantParenthesis extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoBashPrompt.php
+++ b/src/Rule/NoBashPrompt.php
@@ -29,7 +29,7 @@ use App\Value\ViolationInterface;
 #[Description('Ensure no bash prompt `$` is used before commands in `bash`, `shell` or `terminal` code blocks.')]
 #[InvalidExample('$ bin/console list')]
 #[ValidExample('bin/console list')]
-class NoBashPrompt extends AbstractRule implements LineContentRule
+final class NoBashPrompt extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoBlankLineAfterFilepathInCodeBlock.php
+++ b/src/Rule/NoBlankLineAfterFilepathInCodeBlock.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoBlankLineAfterFilepathInCodeBlock extends AbstractRule implements LineContentRule
+final class NoBlankLineAfterFilepathInCodeBlock extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {

--- a/src/Rule/NoBlankLineAfterFilepathInPhpCodeBlock.php
+++ b/src/Rule/NoBlankLineAfterFilepathInPhpCodeBlock.php
@@ -24,7 +24,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoBlankLineAfterFilepathInPhpCodeBlock extends AbstractRule implements LineContentRule
+final class NoBlankLineAfterFilepathInPhpCodeBlock extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoBlankLineAfterFilepathInTwigCodeBlock.php
+++ b/src/Rule/NoBlankLineAfterFilepathInTwigCodeBlock.php
@@ -24,7 +24,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoBlankLineAfterFilepathInTwigCodeBlock extends AbstractRule implements LineContentRule
+final class NoBlankLineAfterFilepathInTwigCodeBlock extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoBlankLineAfterFilepathInXmlCodeBlock.php
+++ b/src/Rule/NoBlankLineAfterFilepathInXmlCodeBlock.php
@@ -24,7 +24,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoBlankLineAfterFilepathInXmlCodeBlock extends AbstractRule implements LineContentRule
+final class NoBlankLineAfterFilepathInXmlCodeBlock extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoBlankLineAfterFilepathInYamlCodeBlock.php
+++ b/src/Rule/NoBlankLineAfterFilepathInYamlCodeBlock.php
@@ -24,7 +24,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoBlankLineAfterFilepathInYamlCodeBlock extends AbstractRule implements LineContentRule
+final class NoBlankLineAfterFilepathInYamlCodeBlock extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoBracketsInMethodDirective.php
+++ b/src/Rule/NoBracketsInMethodDirective.php
@@ -28,7 +28,7 @@ use App\Value\ViolationInterface;
 #[Description('Ensure a :method: directive has special format.')]
 #[InvalidExample(':method:`Symfony\\\\Component\\\\OptionsResolver\\\\Options::offsetGet()`')]
 #[ValidExample(':method:`Symfony\\\\Component\\\\OptionsResolver\\\\Options::offsetGet`')]
-class NoBracketsInMethodDirective extends AbstractRule implements LineContentRule
+final class NoBracketsInMethodDirective extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoComposerPhar.php
+++ b/src/Rule/NoComposerPhar.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoComposerPhar extends AbstractRule implements LineContentRule
+final class NoComposerPhar extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoComposerReq.php
+++ b/src/Rule/NoComposerReq.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoComposerReq extends AbstractRule implements LineContentRule
+final class NoComposerReq extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoConfigYaml.php
+++ b/src/Rule/NoConfigYaml.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoConfigYaml extends AbstractRule implements LineContentRule
+final class NoConfigYaml extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoContraction.php
+++ b/src/Rule/NoContraction.php
@@ -28,7 +28,7 @@ use App\Value\ViolationInterface;
 #[Description('Ensure contractions are not used.')]
 #[InvalidExample("It's an example")]
 #[ValidExample('It is an example')]
-class NoContraction extends CheckListRule implements LineContentRule
+final class NoContraction extends CheckListRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoDirectiveAfterShorthand.php
+++ b/src/Rule/NoDirectiveAfterShorthand.php
@@ -25,7 +25,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Ensure that no directive follows the shorthand `::`. This could lead to broken markup.')]
-class NoDirectiveAfterShorthand extends AbstractRule implements LineContentRule
+final class NoDirectiveAfterShorthand extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoDuplicateUseStatements.php
+++ b/src/Rule/NoDuplicateUseStatements.php
@@ -25,7 +25,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Ensure there is not same use statement twice')]
-class NoDuplicateUseStatements extends AbstractRule implements LineContentRule
+final class NoDuplicateUseStatements extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoExplicitUseOfCodeBlockPhp.php
+++ b/src/Rule/NoExplicitUseOfCodeBlockPhp.php
@@ -24,7 +24,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoExplicitUseOfCodeBlockPhp extends AbstractRule implements LineContentRule
+final class NoExplicitUseOfCodeBlockPhp extends AbstractRule implements LineContentRule
 {
     use DirectiveTrait;
 

--- a/src/Rule/NoFootnotes.php
+++ b/src/Rule/NoFootnotes.php
@@ -27,7 +27,7 @@ use App\Value\ViolationInterface;
  */
 #[Description('Make sure there is no footnotes')]
 #[InvalidExample('.. [5] A numerical footnote. Note')]
-class NoFootnotes extends AbstractRule implements LineContentRule
+final class NoFootnotes extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoInheritdocInCodeExamples.php
+++ b/src/Rule/NoInheritdocInCodeExamples.php
@@ -23,7 +23,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoInheritdocInCodeExamples extends AbstractRule implements LineContentRule
+final class NoInheritdocInCodeExamples extends AbstractRule implements LineContentRule
 {
     use DirectiveTrait;
 

--- a/src/Rule/NoNamespaceAfterUseStatements.php
+++ b/src/Rule/NoNamespaceAfterUseStatements.php
@@ -23,7 +23,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoNamespaceAfterUseStatements extends AbstractRule implements LineContentRule
+final class NoNamespaceAfterUseStatements extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoPhpOpenTagInCodeBlockPhpDirective.php
+++ b/src/Rule/NoPhpOpenTagInCodeBlockPhpDirective.php
@@ -23,7 +23,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoPhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineContentRule
+final class NoPhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoPhpPrefixBeforeBinConsole.php
+++ b/src/Rule/NoPhpPrefixBeforeBinConsole.php
@@ -28,7 +28,7 @@ use App\Value\ViolationInterface;
 #[Description('Ensure `bin/console` is not prefixed with `php`.')]
 #[InvalidExample('php bin/console list')]
 #[ValidExample('bin/console list')]
-class NoPhpPrefixBeforeBinConsole extends AbstractRule implements LineContentRule
+final class NoPhpPrefixBeforeBinConsole extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoPhpPrefixBeforeComposer.php
+++ b/src/Rule/NoPhpPrefixBeforeComposer.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoPhpPrefixBeforeComposer extends AbstractRule implements LineContentRule
+final class NoPhpPrefixBeforeComposer extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/NoSpaceBeforeSelfXmlClosingTag.php
+++ b/src/Rule/NoSpaceBeforeSelfXmlClosingTag.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class NoSpaceBeforeSelfXmlClosingTag extends AbstractRule implements LineContentRule
+final class NoSpaceBeforeSelfXmlClosingTag extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/OnlyBackslashesInNamespaceInPhpCodeBlock.php
+++ b/src/Rule/OnlyBackslashesInNamespaceInPhpCodeBlock.php
@@ -29,7 +29,7 @@ use App\Value\ViolationInterface;
 #[Description('A namespace declaration in a PHP code-block should only contain backslashes.')]
 #[InvalidExample('namespace Foo/Bar;')]
 #[ValidExample('namespace Foo\\Bar;')]
-class OnlyBackslashesInNamespaceInPhpCodeBlock extends AbstractRule implements LineContentRule
+final class OnlyBackslashesInNamespaceInPhpCodeBlock extends AbstractRule implements LineContentRule
 {
     use DirectiveTrait;
 

--- a/src/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlock.php
+++ b/src/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlock.php
@@ -29,7 +29,7 @@ use App\Value\ViolationInterface;
 #[Description('A use statement in a PHP code-block should only contain backslashes.')]
 #[InvalidExample('use Foo/Bar;')]
 #[ValidExample('use Foo\\Bar;')]
-class OnlyBackslashesInUseStatementsInPhpCodeBlock extends AbstractRule implements LineContentRule
+final class OnlyBackslashesInUseStatementsInPhpCodeBlock extends AbstractRule implements LineContentRule
 {
     use DirectiveTrait;
 

--- a/src/Rule/OrderedUseStatements.php
+++ b/src/Rule/OrderedUseStatements.php
@@ -25,7 +25,7 @@ use function Symfony\Component\String\u;
 /**
  * @no-named-arguments
  */
-class OrderedUseStatements extends AbstractRule implements LineContentRule
+final class OrderedUseStatements extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/PhpOpenTagInCodeBlockPhpDirective.php
+++ b/src/Rule/PhpOpenTagInCodeBlockPhpDirective.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class PhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineContentRule
+final class PhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {

--- a/src/Rule/PhpPrefixBeforeBinConsole.php
+++ b/src/Rule/PhpPrefixBeforeBinConsole.php
@@ -29,7 +29,7 @@ use App\Value\ViolationInterface;
 #[Description('Ensure `bin/console` is prefixed with `php` to be safe executable on Microsoft Windows.')]
 #[InvalidExample('bin/console list')]
 #[ValidExample('php bin/console list')]
-class PhpPrefixBeforeBinConsole extends AbstractRule implements LineContentRule
+final class PhpPrefixBeforeBinConsole extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/RemoveTrailingWhitespace.php
+++ b/src/Rule/RemoveTrailingWhitespace.php
@@ -28,7 +28,7 @@ use App\Value\ViolationInterface;
 #[Description('Make sure there is not trailing whitespace.')]
 #[InvalidExample('Invalid sentence ')]
 #[ValidExample('Valid sentence')]
-class RemoveTrailingWhitespace extends AbstractRule implements LineContentRule
+final class RemoveTrailingWhitespace extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/ReplaceCodeBlockTypes.php
+++ b/src/Rule/ReplaceCodeBlockTypes.php
@@ -25,7 +25,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Propose alternatives for disallowed code block types.')]
-class ReplaceCodeBlockTypes extends CheckListRule implements LineContentRule
+final class ReplaceCodeBlockTypes extends CheckListRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/Replacement.php
+++ b/src/Rule/Replacement.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class Replacement extends CheckListRule implements LineContentRule
+final class Replacement extends CheckListRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/ShortArraySyntax.php
+++ b/src/Rule/ShortArraySyntax.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class ShortArraySyntax extends AbstractRule implements LineContentRule
+final class ShortArraySyntax extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/SpaceBeforeSelfXmlClosingTag.php
+++ b/src/Rule/SpaceBeforeSelfXmlClosingTag.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class SpaceBeforeSelfXmlClosingTag extends AbstractRule implements LineContentRule
+final class SpaceBeforeSelfXmlClosingTag extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {

--- a/src/Rule/SpaceBetweenLabelAndLinkInDoc.php
+++ b/src/Rule/SpaceBetweenLabelAndLinkInDoc.php
@@ -29,7 +29,7 @@ use function Symfony\Component\String\u;
 #[Description('Ensure a space between label and link in :doc: directive.')]
 #[InvalidExample(':doc:`File</reference/constraints/File>`')]
 #[ValidExample(':doc:`File </reference/constraints/File>`')]
-class SpaceBetweenLabelAndLinkInDoc extends AbstractRule implements LineContentRule
+final class SpaceBetweenLabelAndLinkInDoc extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/SpaceBetweenLabelAndLinkInRef.php
+++ b/src/Rule/SpaceBetweenLabelAndLinkInRef.php
@@ -29,7 +29,7 @@ use function Symfony\Component\String\u;
 #[Description('Ensure a space between label and link in :ref: directive.')]
 #[InvalidExample(':ref:`receiving them via a worker<messenger-worker>`')]
 #[ValidExample(':ref:`receiving them via a worker <messenger-worker>`')]
-class SpaceBetweenLabelAndLinkInRef extends AbstractRule implements LineContentRule
+final class SpaceBetweenLabelAndLinkInRef extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/StringReplacement.php
+++ b/src/Rule/StringReplacement.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class StringReplacement extends CheckListRule implements LineContentRule
+final class StringReplacement extends CheckListRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/TitleUnderlineLengthMustMatchTitleLength.php
+++ b/src/Rule/TitleUnderlineLengthMustMatchTitleLength.php
@@ -21,7 +21,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class TitleUnderlineLengthMustMatchTitleLength extends AbstractRule implements LineContentRule
+final class TitleUnderlineLengthMustMatchTitleLength extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {

--- a/src/Rule/Typo.php
+++ b/src/Rule/Typo.php
@@ -24,7 +24,7 @@ use App\Value\ViolationInterface;
  * @no-named-arguments
  */
 #[Description('Report common typos.')]
-class Typo extends CheckListRule implements LineContentRule
+final class Typo extends CheckListRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/UnusedLinks.php
+++ b/src/Rule/UnusedLinks.php
@@ -28,7 +28,7 @@ use Symfony\Contracts\Service\ResetInterface;
  * @no-named-arguments
  */
 #[Description('Report all links which are defined, but not used in the file anymore.')]
-class UnusedLinks extends AbstractRule implements FileContentRule, ResetInterface
+final class UnusedLinks extends AbstractRule implements FileContentRule, ResetInterface
 {
     /**
      * @var LinkUsage[]

--- a/src/Rule/UseDeprecatedDirectiveInsteadOfVersionadded.php
+++ b/src/Rule/UseDeprecatedDirectiveInsteadOfVersionadded.php
@@ -23,7 +23,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class UseDeprecatedDirectiveInsteadOfVersionadded extends AbstractRule implements LineContentRule
+final class UseDeprecatedDirectiveInsteadOfVersionadded extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/UseHttpsXsdUrls.php
+++ b/src/Rule/UseHttpsXsdUrls.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class UseHttpsXsdUrls extends AbstractRule implements LineContentRule
+final class UseHttpsXsdUrls extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/ValidInlineHighlightedNamespaces.php
+++ b/src/Rule/ValidInlineHighlightedNamespaces.php
@@ -31,7 +31,7 @@ use App\Value\ViolationInterface;
 #[ValidExample('`App\\\\Entity\\\\Foo`')]
 #[InvalidExample('``App\\\\Entity\\\\Foo``')]
 #[InvalidExample('`App\\Entity\\Foo`')]
-class ValidInlineHighlightedNamespaces extends AbstractRule implements LineContentRule
+final class ValidInlineHighlightedNamespaces extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/ValidUseStatements.php
+++ b/src/Rule/ValidUseStatements.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 /**
  * @no-named-arguments
  */
-class ValidUseStatements extends AbstractRule implements LineContentRule
+final class ValidUseStatements extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/VersionaddedDirectiveMajorVersion.php
+++ b/src/Rule/VersionaddedDirectiveMajorVersion.php
@@ -25,7 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @no-named-arguments
  */
-class VersionaddedDirectiveMajorVersion extends AbstractRule implements Configurable, LineContentRule
+final class VersionaddedDirectiveMajorVersion extends AbstractRule implements Configurable, LineContentRule
 {
     private int $majorVersion;
 

--- a/src/Rule/VersionaddedDirectiveMinVersion.php
+++ b/src/Rule/VersionaddedDirectiveMinVersion.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @no-named-arguments
  */
-class VersionaddedDirectiveMinVersion extends AbstractRule implements Configurable, LineContentRule
+final class VersionaddedDirectiveMinVersion extends AbstractRule implements Configurable, LineContentRule
 {
     private string $minVersion;
 

--- a/src/Rule/VersionaddedDirectiveShouldHaveVersion.php
+++ b/src/Rule/VersionaddedDirectiveShouldHaveVersion.php
@@ -31,7 +31,7 @@ use Composer\Semver\VersionParser;
 #[ValidExample('.. versionadded:: 3.4')]
 #[InvalidExample('.. versionadded::')]
 #[InvalidExample('.. versionadded:: foo-bar')]
-class VersionaddedDirectiveShouldHaveVersion extends AbstractRule implements LineContentRule
+final class VersionaddedDirectiveShouldHaveVersion extends AbstractRule implements LineContentRule
 {
     public function __construct(
         private readonly VersionParser $versionParser,

--- a/src/Rule/YamlInsteadOfYmlSuffix.php
+++ b/src/Rule/YamlInsteadOfYmlSuffix.php
@@ -32,7 +32,7 @@ use App\Value\ViolationInterface;
 #[ValidExample('Please add this to your services.yaml file.')]
 #[InvalidExample('..code-block:: yml')]
 #[InvalidExample('Please add this to your services.yml file.')]
-class YamlInsteadOfYmlSuffix extends AbstractRule implements LineContentRule
+final class YamlInsteadOfYmlSuffix extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/YarnDevOptionAtTheEnd.php
+++ b/src/Rule/YarnDevOptionAtTheEnd.php
@@ -28,7 +28,7 @@ use App\Value\ViolationInterface;
 #[Description('Make sure yarn `--dev` option for `add` command is used at the end.')]
 #[InvalidExample('yarn add --dev jquery')]
 #[ValidExample('yarn add jquery --dev')]
-class YarnDevOptionAtTheEnd extends AbstractRule implements LineContentRule
+final class YarnDevOptionAtTheEnd extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array
     {

--- a/src/Rule/YarnDevOptionNotAtTheEnd.php
+++ b/src/Rule/YarnDevOptionNotAtTheEnd.php
@@ -27,7 +27,7 @@ use App\Value\ViolationInterface;
 #[Description('Make sure yarn `--dev` option for `add` command is used at the end.')]
 #[ValidExample('yarn add --dev jquery')]
 #[InvalidExample('yarn add jquery --dev')]
-class YarnDevOptionNotAtTheEnd extends AbstractRule implements LineContentRule
+final class YarnDevOptionNotAtTheEnd extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface
     {


### PR DESCRIPTION
## Summary
- Mark all 91 concrete rule classes as `final` to prevent unintended inheritance
- Abstract classes (`AbstractRule`, `CheckListRule`) and interfaces remain unchanged

## Test plan
- [x] All tests pass (classes can still be instantiated)
- [ ] Verify no subclasses exist in any consuming code