### PR TITLE
Handle link definitions in code-block:: rst differently

### DIFF
--- a/src/Rule/EnsureLinkBottom.php
+++ b/src/Rule/EnsureLinkBottom.php
@@ -15,6 +15,8 @@ namespace App\Rule;
 
 use App\Attribute\Rule\Description;
 use App\Rst\RstParser;
+use App\Traits\DirectiveTrait;
+use App\Value\Line;
 use App\Value\Lines;
 use App\Value\NullViolation;
 use App\Value\RuleGroup;
@@ -27,6 +29,8 @@ use App\Value\ViolationInterface;
 #[Description('Ensure link lines are at the bottom of the file.')]
 final class EnsureLinkBottom extends AbstractRule implements LineContentRule
 {
+    use DirectiveTrait;
+
     public static function getGroups(): array
     {
         return [RuleGroup::Symfony()];
@@ -40,6 +44,24 @@ final class EnsureLinkBottom extends AbstractRule implements LineContentRule
         if (!RstParser::isLinkDefinition($line)) {
             return NullViolation::create();
         }
+
+        $inRstCodeBlock = $this->in(
+            RstParser::DIRECTIVE_CODE_BLOCK,
+            $lines,
+            $number,
+            [RstParser::CODE_BLOCK_RST],
+        );
+
+        if ($inRstCodeBlock) {
+            return self::checkLinkAtEndOfCodeBlock($lines, $number, $filename, $line);
+        }
+
+        return self::checkLinkAtEndOfFile($lines, $number, $filename, $line);
+    }
+
+    private static function checkLinkAtEndOfFile(Lines $lines, int $number, string $filename, Line $line): ViolationInterface
+    {
+        $lines->seek($number);
 
         while ($lines->valid()) {
             $lines->next();
@@ -57,6 +79,42 @@ final class EnsureLinkBottom extends AbstractRule implements LineContentRule
             if (!RstParser::isLinkDefinition($current)) {
                 return Violation::from(
                     'Please move link definition to the bottom of the page',
+                    $filename,
+                    $number + 1,
+                    $line,
+                );
+            }
+        }
+
+        return NullViolation::create();
+    }
+
+    private static function checkLinkAtEndOfCodeBlock(Lines $lines, int $number, string $filename, Line $line): ViolationInterface
+    {
+        $lines->seek($number);
+        $codeBlockIndention = $line->indention();
+
+        while ($lines->valid()) {
+            $lines->next();
+
+            if (!$lines->valid()) {
+                break;
+            }
+
+            $current = $lines->current();
+
+            if ($current->isBlank()) {
+                continue;
+            }
+
+            // If we hit a line with less indention, we've left the code block
+            if ($current->indention() < $codeBlockIndention) {
+                break;
+            }
+
+            if (!RstParser::isLinkDefinition($current)) {
+                return Violation::from(
+                    'Please move link definition to the bottom of the RST code block',
                     $filename,
                     $number + 1,
                     $line,

--- a/tests/Rule/EnsureLinkBottomTest.php
+++ b/tests/Rule/EnsureLinkBottomTest.php
@@ -92,5 +92,61 @@ final class EnsureLinkBottomTest extends UnitTestCase
                 'text after link',
             ], 1),
         ];
+
+        // Link at end of RST code block - valid
+        yield 'link at end of rst code block is valid' => [
+            NullViolation::create(),
+            new RstSample([
+                '.. code-block:: rst',
+                '',
+                '    Some RST content',
+                '',
+                '    .. _`example-link`: https://example.com',
+            ], 4),
+        ];
+
+        // Multiple links at end of RST code block - valid
+        yield 'multiple links at end of rst code block are valid' => [
+            NullViolation::create(),
+            new RstSample([
+                '.. code-block:: rst',
+                '',
+                '    Some RST content',
+                '',
+                '    .. _`first-link`: https://foo.bar',
+                '    .. _`second-link`: https://foo.baz',
+            ], 4),
+        ];
+
+        // Link not at end of RST code block - invalid
+        yield 'link not at end of rst code block is invalid' => [
+            Violation::from(
+                'Please move link definition to the bottom of the RST code block',
+                'filename',
+                4,
+                '.. _`example-link`: https://example.com',
+            ),
+            new RstSample([
+                '.. code-block:: rst',
+                '',
+                '    Some RST content',
+                '    .. _`example-link`: https://example.com',
+                '    More content after link',
+            ], 3),
+        ];
+
+        // Link at end of RST code block, content continues outside - valid
+        yield 'link at end of rst code block with content after code block is valid' => [
+            NullViolation::create(),
+            new RstSample([
+                '.. code-block:: rst',
+                '',
+                '    Some RST content',
+                '',
+                '    .. _`example-link`: https://example.com',
+                '',
+                'Content outside code block',
+            ], 4),
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- Link definitions inside `code-block:: rst` are now validated to be at the end of the code block (not the end of the file)
- This allows documenting RST link syntax in code examples without false positives
- Links inside RST code blocks that are followed by other content in the code block will trigger a violation

## Test plan
- [x] Added test for link at end of RST code block (valid)
- [x] Added test for multiple links at end of RST code block (valid)
- [x] Added test for link not at end of RST code block (invalid)
- [x] Added test for link at end of RST code block with content after the code block (valid)
- [x] All existing tests pass
- [x] PHPStan passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)