### PR TITLE
Remove @no-named-arguments annotations

### DIFF
--- a/src/Analyzer/Analyzer.php
+++ b/src/Analyzer/Analyzer.php
@@ -16,9 +16,6 @@ namespace App\Analyzer;
 use App\Rule\Rule;
 use App\Value\Violation;
 
-/**
- * @no-named-arguments
- */
 interface Analyzer
 {
     /**

--- a/src/Analyzer/Cache.php
+++ b/src/Analyzer/Cache.php
@@ -16,9 +16,6 @@ namespace App\Analyzer;
 use App\Rule\Rule;
 use App\Value\Violation;
 
-/**
- * @no-named-arguments
- */
 interface Cache
 {
     /**

--- a/src/Analyzer/FileCache.php
+++ b/src/Analyzer/FileCache.php
@@ -16,9 +16,6 @@ namespace App\Analyzer;
 use App\Application;
 use App\Value\Violation;
 
-/**
- * @no-named-arguments
- */
 final class FileCache implements Cache
 {
     /**

--- a/src/Analyzer/InMemoryCache.php
+++ b/src/Analyzer/InMemoryCache.php
@@ -15,9 +15,6 @@ namespace App\Analyzer;
 
 use App\Value\Violation;
 
-/**
- * @no-named-arguments
- */
 final class InMemoryCache implements Cache
 {
     /**

--- a/src/Analyzer/MemoizingAnalyzer.php
+++ b/src/Analyzer/MemoizingAnalyzer.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Analyzer;
 
-/**
- * @no-named-arguments
- */
 final readonly class MemoizingAnalyzer implements Analyzer
 {
     public function __construct(

--- a/src/Analyzer/RstAnalyzer.php
+++ b/src/Analyzer/RstAnalyzer.php
@@ -21,9 +21,6 @@ use App\Value\Lines;
 use App\Value\ViolationInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
-/**
- * @no-named-arguments
- */
 final class RstAnalyzer implements Analyzer
 {
     /**

--- a/src/Application.php
+++ b/src/Application.php
@@ -23,9 +23,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
-/**
- * @no-named-arguments
- */
 class Application extends BaseApplication
 {
     public const string VERSION = '@git-version@';

--- a/src/Attribute/Rule/Description.php
+++ b/src/Attribute/Rule/Description.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Attribute\Rule;
 
-/**
- * @no-named-arguments
- */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class Description
 {

--- a/src/Attribute/Rule/InvalidExample.php
+++ b/src/Attribute/Rule/InvalidExample.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Attribute\Rule;
 
-/**
- * @no-named-arguments
- */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class InvalidExample
 {

--- a/src/Attribute/Rule/ValidExample.php
+++ b/src/Attribute/Rule/ValidExample.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Attribute\Rule;
 
-/**
- * @no-named-arguments
- */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class ValidExample
 {

--- a/src/Command/AnalyzeCommand.php
+++ b/src/Command/AnalyzeCommand.php
@@ -35,9 +35,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
-/**
- * @no-named-arguments
- */
 #[AsCommand('analyze', null, ['analyse'])]
 class AnalyzeCommand extends Command
 {

--- a/src/Command/RulesCommand.php
+++ b/src/Command/RulesCommand.php
@@ -29,9 +29,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\OptionsResolver\Debug\OptionsResolverIntrospector;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @no-named-arguments
- */
 #[AsCommand('rules', 'List available rules')]
 class RulesCommand extends Command
 {

--- a/src/Formatter/ConsoleFormatter.php
+++ b/src/Formatter/ConsoleFormatter.php
@@ -18,9 +18,6 @@ use App\Value\FileResult;
 use App\Value\Violation;
 use Symfony\Component\Console\Style\OutputStyle;
 
-/**
- * @no-named-arguments
- */
 class ConsoleFormatter implements Formatter
 {
     public function format(

--- a/src/Formatter/Exception/FormatterNotFound.php
+++ b/src/Formatter/Exception/FormatterNotFound.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Formatter\Exception;
 
-/**
- * @no-named-arguments
- */
 final class FormatterNotFound extends \InvalidArgumentException
 {
     public static function byName(string $name): self

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -16,9 +16,6 @@ namespace App\Formatter;
 use App\Value\AnalyzerResult;
 use Symfony\Component\Console\Style\OutputStyle;
 
-/**
- * @no-named-arguments
- */
 interface Formatter
 {
     public function format(OutputStyle $style, AnalyzerResult $analyzerResult, string $analyzeDir, bool $showValidFiles): void;

--- a/src/Formatter/GithubFormatter.php
+++ b/src/Formatter/GithubFormatter.php
@@ -16,9 +16,6 @@ namespace App\Formatter;
 use App\Value\AnalyzerResult;
 use Symfony\Component\Console\Style\OutputStyle;
 
-/**
- * @no-named-arguments
- */
 class GithubFormatter implements Formatter
 {
     public function __construct(

--- a/src/Formatter/Registry.php
+++ b/src/Formatter/Registry.php
@@ -15,9 +15,6 @@ namespace App\Formatter;
 
 use App\Formatter\Exception\FormatterNotFound;
 
-/**
- * @no-named-arguments
- */
 final class Registry
 {
     /**

--- a/src/Handler/Registry.php
+++ b/src/Handler/Registry.php
@@ -18,9 +18,6 @@ use App\Rule\Rule;
 use App\Value\RuleGroup;
 use App\Value\RuleName;
 
-/**
- * @no-named-arguments
- */
 final class Registry
 {
     /**

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Helper;
 
-/**
- * @no-named-arguments
- */
 class Helper
 {
     public static function cloneIterator(\ArrayIterator $iterator, int $number): \ArrayIterator

--- a/src/Helper/PhpHelper.php
+++ b/src/Helper/PhpHelper.php
@@ -16,9 +16,6 @@ namespace App\Helper;
 use App\Value\Line;
 use App\Value\Lines;
 
-/**
- * @no-named-arguments
- */
 final class PhpHelper
 {
     private const string REGEX_NAMESPACE_WITH_TWO_BACKSLASHES = '((?:\\\\{0,2}\w+|\w+\\\\{2})(?:\w+\\\\{2})+)';

--- a/src/Helper/TwigHelper.php
+++ b/src/Helper/TwigHelper.php
@@ -15,9 +15,6 @@ namespace App\Helper;
 
 use App\Value\Line;
 
-/**
- * @no-named-arguments
- */
 final class TwigHelper
 {
     public static function isComment(Line $line, ?bool $closed = null): bool

--- a/src/Helper/XmlHelper.php
+++ b/src/Helper/XmlHelper.php
@@ -15,9 +15,6 @@ namespace App\Helper;
 
 use App\Value\Line;
 
-/**
- * @no-named-arguments
- */
 final class XmlHelper
 {
     public static function isComment(Line $line, ?bool $closed = null): bool

--- a/src/Helper/YamlHelper.php
+++ b/src/Helper/YamlHelper.php
@@ -15,9 +15,6 @@ namespace App\Helper;
 
 use App\Value\Line;
 
-/**
- * @no-named-arguments
- */
 final class YamlHelper
 {
     public static function isComment(Line $line): bool

--- a/src/Rst/RstParser.php
+++ b/src/Rst/RstParser.php
@@ -17,9 +17,6 @@ use App\Value\Line;
 use Webmozart\Assert\Assert;
 use function Symfony\Component\String\u;
 
-/**
- * @no-named-arguments
- */
 class RstParser
 {
     final public const string SHORTHAND = '::';

--- a/src/Rst/Value/DirectiveContent.php
+++ b/src/Rst/Value/DirectiveContent.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Rst\Value;
 
-/**
- * @no-named-arguments
- */
 final class DirectiveContent
 {
     public array $cleaned = [];

--- a/src/Rst/Value/LinkDefinition.php
+++ b/src/Rst/Value/LinkDefinition.php
@@ -15,9 +15,6 @@ namespace App\Rst\Value;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @no-named-arguments
- */
 final readonly class LinkDefinition
 {
     private function __construct(

--- a/src/Rst/Value/LinkName.php
+++ b/src/Rst/Value/LinkName.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Rst\Value;
 
-/**
- * @no-named-arguments
- */
 final readonly class LinkName
 {
     private string $value;

--- a/src/Rst/Value/LinkUrl.php
+++ b/src/Rst/Value/LinkUrl.php
@@ -15,9 +15,6 @@ namespace App\Rst\Value;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @no-named-arguments
- */
 final readonly class LinkUrl
 {
     private string $value;

--- a/src/Rst/Value/LinkUsage.php
+++ b/src/Rst/Value/LinkUsage.php
@@ -15,9 +15,6 @@ namespace App\Rst\Value;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @no-named-arguments
- */
 final readonly class LinkUsage
 {
     private function __construct(

--- a/src/Rule/AbstractRule.php
+++ b/src/Rule/AbstractRule.php
@@ -16,9 +16,6 @@ namespace App\Rule;
 use App\Value\RuleGroup;
 use App\Value\RuleName;
 
-/**
- * @no-named-arguments
- */
 abstract class AbstractRule
 {
     public static function getName(): RuleName

--- a/src/Rule/AmericanEnglish.php
+++ b/src/Rule/AmericanEnglish.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure only American English is used.')]
 #[InvalidExample('This is a nice behaviour...')]
 #[ValidExample('This is a nice behavior...')]

--- a/src/Rule/ArgumentVariableMustMatchType.php
+++ b/src/Rule/ArgumentVariableMustMatchType.php
@@ -21,9 +21,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure argument variable name match for type')]
 final class ArgumentVariableMustMatchType extends AbstractRule implements Configurable, LineContentRule
 {

--- a/src/Rule/AvoidRepetetiveWords.php
+++ b/src/Rule/AvoidRepetetiveWords.php
@@ -28,9 +28,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure that a word is not used twice in a row.')]
 #[ValidExample('Please do not use it this way...')]
 #[InvalidExample('Please do not not use it this way...')]

--- a/src/Rule/BeKindToNewcomers.php
+++ b/src/Rule/BeKindToNewcomers.php
@@ -20,9 +20,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Do not use belittling words!')]
 final class BeKindToNewcomers extends CheckListRule implements LineContentRule
 {

--- a/src/Rule/BlankLineAfterAnchor.php
+++ b/src/Rule/BlankLineAfterAnchor.php
@@ -21,9 +21,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure you have a blank line after anchor (`.. anchor:`).')]
 final class BlankLineAfterAnchor extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/BlankLineAfterColon.php
+++ b/src/Rule/BlankLineAfterColon.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure you have a blank line after a sentence which ends with a colon (`:`).')]
 final class BlankLineAfterColon extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/BlankLineAfterDirective.php
+++ b/src/Rule/BlankLineAfterDirective.php
@@ -21,9 +21,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure you have a blank line after each directive.')]
 final class BlankLineAfterDirective extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/BlankLineAfterFilepathInCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInCodeBlock.php
@@ -21,9 +21,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure you have a blank line after a filepath in a code block. This rule respects PHP, YAML, XML and Twig.')]
 final class BlankLineAfterFilepathInCodeBlock extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/BlankLineAfterFilepathInPhpCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInPhpCodeBlock.php
@@ -21,9 +21,6 @@ use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure you have a blank line after a filepath in a PHP code block.')]
 final class BlankLineAfterFilepathInPhpCodeBlock extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/BlankLineAfterFilepathInTwigCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInTwigCodeBlock.php
@@ -21,9 +21,6 @@ use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure you have a blank line after a filepath in a Twig code block.')]
 final class BlankLineAfterFilepathInTwigCodeBlock extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/BlankLineAfterFilepathInXmlCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInXmlCodeBlock.php
@@ -21,9 +21,6 @@ use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure you have a blank line after a filepath in a XML code block.')]
 final class BlankLineAfterFilepathInXmlCodeBlock extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/BlankLineAfterFilepathInYamlCodeBlock.php
+++ b/src/Rule/BlankLineAfterFilepathInYamlCodeBlock.php
@@ -21,9 +21,6 @@ use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure you have a blank line after a filepath in a YAML code block.')]
 final class BlankLineAfterFilepathInYamlCodeBlock extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/BlankLineBeforeDirective.php
+++ b/src/Rule/BlankLineBeforeDirective.php
@@ -21,9 +21,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure you have a blank line before each directive.')]
 final class BlankLineBeforeDirective extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/CheckListRule.php
+++ b/src/Rule/CheckListRule.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Rule;
 
-/**
- * @no-named-arguments
- */
 abstract class CheckListRule extends AbstractRule
 {
     public string $search;

--- a/src/Rule/ComposerDevOptionAtTheEnd.php
+++ b/src/Rule/ComposerDevOptionAtTheEnd.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure Composer `--dev` option for `require` command is used at the end.')]
 #[InvalidExample('composer require --dev symfony/var-dumper')]
 #[ValidExample('composer require symfony/var-dumper --dev')]

--- a/src/Rule/ComposerDevOptionNotAtTheEnd.php
+++ b/src/Rule/ComposerDevOptionNotAtTheEnd.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure Composer `--dev` option for `require` command is not used at the end.')]
 #[InvalidExample('composer require symfony/var-dumper --dev')]
 #[ValidExample('composer require --dev symfony/var-dumper')]

--- a/src/Rule/Configurable.php
+++ b/src/Rule/Configurable.php
@@ -15,9 +15,6 @@ namespace App\Rule;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @no-named-arguments
- */
 interface Configurable
 {
     public function configureOptions(OptionsResolver $resolver): OptionsResolver;

--- a/src/Rule/CorrectCodeBlockDirectiveBasedOnTheContent.php
+++ b/src/Rule/CorrectCodeBlockDirectiveBasedOnTheContent.php
@@ -20,9 +20,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class CorrectCodeBlockDirectiveBasedOnTheContent extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/DeprecatedDirectiveMajorVersion.php
+++ b/src/Rule/DeprecatedDirectiveMajorVersion.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use Composer\Semver\VersionParser;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @no-named-arguments
- */
 final class DeprecatedDirectiveMajorVersion extends AbstractRule implements Configurable, LineContentRule
 {
     private int $majorVersion;

--- a/src/Rule/DeprecatedDirectiveMinVersion.php
+++ b/src/Rule/DeprecatedDirectiveMinVersion.php
@@ -21,9 +21,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @no-named-arguments
- */
 final class DeprecatedDirectiveMinVersion extends AbstractRule implements Configurable, LineContentRule
 {
     private string $minVersion;

--- a/src/Rule/DeprecatedDirectiveShouldHaveVersion.php
+++ b/src/Rule/DeprecatedDirectiveShouldHaveVersion.php
@@ -24,9 +24,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use Composer\Semver\VersionParser;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure a deprecated directive has a version which follows SemVer.')]
 #[ValidExample('.. deprecated:: 3.4')]
 #[InvalidExample('.. deprecated::')]

--- a/src/Rule/EnsureBashPromptBeforeComposerCommand.php
+++ b/src/Rule/EnsureBashPromptBeforeComposerCommand.php
@@ -24,9 +24,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure Composer command in a terminal/bash code block is prefixed with a $.')]
 #[InvalidExample('composer require symfony/var-dumper')]
 #[ValidExample('$ composer require symfony/var-dumper')]

--- a/src/Rule/EnsureClassConstant.php
+++ b/src/Rule/EnsureClassConstant.php
@@ -22,9 +22,6 @@ use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure to use ::class over get_class')]
 #[InvalidExample('get_class(new MyClass())')]
 #[ValidExample('MyClass::class')]

--- a/src/Rule/EnsureCorrectFormatForPhpfunction.php
+++ b/src/Rule/EnsureCorrectFormatForPhpfunction.php
@@ -21,9 +21,6 @@ use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure phpfunction directive do not end with ().')]
 #[InvalidExample(':phpfunction:`mb_detect_encoding()`.')]
 #[ValidExample(':phpfunction:`mb_detect_encoding`.')]

--- a/src/Rule/EnsureExactlyOneSpaceBeforeDirectiveType.php
+++ b/src/Rule/EnsureExactlyOneSpaceBeforeDirectiveType.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure exactly one space before directive type.')]
 #[InvalidExample('..  code-block:: php')]
 #[ValidExample('.. code-block:: php')]

--- a/src/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink.php
+++ b/src/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink.php
@@ -23,9 +23,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure exactly one space between link definition and link.')]
 #[InvalidExample('.. _DOCtor-RST:     https://github.com/OskarStark/DOCtor-RST')]
 #[ValidExample('.. _DOCtor-RST: https://github.com/OskarStark/DOCtor-RST')]

--- a/src/Rule/EnsureExplicitNullableTypes.php
+++ b/src/Rule/EnsureExplicitNullableTypes.php
@@ -23,9 +23,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure explicit nullable types in method arguments.')]
 #[ValidExample('function foo(?string $bar = null)')]
 #[ValidExample('function foo(string|null $bar = null)')]

--- a/src/Rule/EnsureGithubDirectiveStartWithPrefix.php
+++ b/src/Rule/EnsureGithubDirectiveStartWithPrefix.php
@@ -19,9 +19,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @no-named-arguments
- */
 final class EnsureGithubDirectiveStartWithPrefix extends AbstractRule implements Configurable, LineContentRule
 {
     private string $prefix;

--- a/src/Rule/EnsureLinkBottom.php
+++ b/src/Rule/EnsureLinkBottom.php
@@ -23,9 +23,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure link lines are at the bottom of the file.')]
 final class EnsureLinkBottom extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/EnsureLinkDefinitionContainsValidUrl.php
+++ b/src/Rule/EnsureLinkDefinitionContainsValidUrl.php
@@ -24,9 +24,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure link definition contains valid link.')]
 #[InvalidExample('.. _DOCtor-RST: htt//github.com/OskarStark/DOCtor-RST')]
 #[ValidExample('.. _DOCtor-RST: https://github.com/OskarStark/DOCtor-RST')]

--- a/src/Rule/EnsureOrderOfCodeBlocksInConfigurationBlock.php
+++ b/src/Rule/EnsureOrderOfCodeBlocksInConfigurationBlock.php
@@ -21,9 +21,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use Webmozart\Assert\Assert;
 
-/**
- * @no-named-arguments
- */
 final class EnsureOrderOfCodeBlocksInConfigurationBlock extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/EnsurePhpReferenceSyntax.php
+++ b/src/Rule/EnsurePhpReferenceSyntax.php
@@ -23,9 +23,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use function Symfony\Component\String\u;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure php reference syntax is valid.')]
 #[InvalidExample('The :class:`Symfony\\Component\\Notifier\\Transport`` class')]
 #[InvalidExample('The :class:`Symfony\\\\AI\\\\Platform\\PlatformInterface` class')]

--- a/src/Rule/ExtendAbstractAdmin.php
+++ b/src/Rule/ExtendAbstractAdmin.php
@@ -20,9 +20,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure `AbstractAdmin` and the corresponding namespace `Sonata\\AdminBundle\\Admin\\AbstractAdmin` is used.')]
 final class ExtendAbstractAdmin extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/ExtendAbstractController.php
+++ b/src/Rule/ExtendAbstractController.php
@@ -20,9 +20,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure `AbstractController` and the corresponding namespace `Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController` is used. Instead of `Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller`.')]
 final class ExtendAbstractController extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/ExtendController.php
+++ b/src/Rule/ExtendController.php
@@ -20,9 +20,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure `Controller` and the corresponding namespace `Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller` is used. Instead of `Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController`.')]
 final class ExtendController extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/ExtensionXlfInsteadOfXliff.php
+++ b/src/Rule/ExtensionXlfInsteadOfXliff.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure to only use `.xlf` instead of `.xliff`.')]
 #[ValidExample('messages.xlf')]
 #[InvalidExample('messages.xliff')]

--- a/src/Rule/FileContentRule.php
+++ b/src/Rule/FileContentRule.php
@@ -20,8 +20,6 @@ use App\Value\ViolationInterface;
  * Rules using this interface are only run once per file, and are
  * responsible to check the whole file content on its own, if needed.
  * They always start on the first line of the document.
- *
- * @no-named-arguments
  */
 interface FileContentRule extends Rule
 {

--- a/src/Rule/FileInfoRule.php
+++ b/src/Rule/FileInfoRule.php
@@ -18,8 +18,6 @@ use App\Value\ViolationInterface;
 /**
  * Rules using this interface are only run once,
  * and get a \SplFileInfo containing infos of the file.
- *
- * @no-named-arguments
  */
 interface FileInfoRule extends Rule
 {

--- a/src/Rule/FilenameUsesDashesOnly.php
+++ b/src/Rule/FilenameUsesDashesOnly.php
@@ -22,9 +22,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use function Symfony\Component\String\u;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensures a filename uses only dashes (`-`), but are allowed to start with underscore (`_`). It is a common practice to prefix included files with underscores (`_`).')]
 #[InvalidExample('custom_extensions.rst')]
 #[ValidExample('custom-extensions.rst')]

--- a/src/Rule/FilenameUsesUnderscoresOnly.php
+++ b/src/Rule/FilenameUsesUnderscoresOnly.php
@@ -22,9 +22,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use function Symfony\Component\String\u;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensures a filename uses only underscores (`_`).')]
 #[InvalidExample('custom-extensions.rst')]
 #[ValidExample('custom_extensions.rst')]

--- a/src/Rule/FinalAdminClasses.php
+++ b/src/Rule/FinalAdminClasses.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class FinalAdminClasses extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/FinalAdminExtensionClasses.php
+++ b/src/Rule/FinalAdminExtensionClasses.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class FinalAdminExtensionClasses extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/ForbiddenDirectives.php
+++ b/src/Rule/ForbiddenDirectives.php
@@ -25,9 +25,6 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure forbidden directives are not used')]
 final class ForbiddenDirectives extends AbstractRule implements Configurable, LineContentRule
 {

--- a/src/Rule/Indention.php
+++ b/src/Rule/Indention.php
@@ -26,9 +26,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @no-named-arguments
- */
 final class Indention extends AbstractRule implements Configurable, LineContentRule
 {
     use DirectiveTrait;

--- a/src/Rule/KernelInsteadOfAppKernel.php
+++ b/src/Rule/KernelInsteadOfAppKernel.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class KernelInsteadOfAppKernel extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/LineContentRule.php
+++ b/src/Rule/LineContentRule.php
@@ -18,8 +18,6 @@ use App\Value\ViolationInterface;
 
 /**
  * Rules using this interface run for every line of the file content.
- *
- * @no-named-arguments
  */
 interface LineContentRule extends Rule
 {

--- a/src/Rule/LineLength.php
+++ b/src/Rule/LineLength.php
@@ -19,9 +19,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @no-named-arguments
- */
 final class LineLength extends AbstractRule implements Configurable, LineContentRule
 {
     private int $max;

--- a/src/Rule/LowercaseAsInUseStatements.php
+++ b/src/Rule/LowercaseAsInUseStatements.php
@@ -20,9 +20,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class LowercaseAsInUseStatements extends AbstractRule implements LineContentRule
 {
     use DirectiveTrait;

--- a/src/Rule/MaxBlankLines.php
+++ b/src/Rule/MaxBlankLines.php
@@ -20,9 +20,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @no-named-arguments
- */
 final class MaxBlankLines extends AbstractRule implements Configurable, LineContentRule
 {
     private int $max;

--- a/src/Rule/MaxColons.php
+++ b/src/Rule/MaxColons.php
@@ -23,9 +23,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure you have max 2 colons (`::`).')]
 #[InvalidExample('temp:::')]
 #[ValidExample('temp::')]

--- a/src/Rule/NoAdminYaml.php
+++ b/src/Rule/NoAdminYaml.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoAdminYaml extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoAppBundle.php
+++ b/src/Rule/NoAppBundle.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoAppBundle extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoAppConsole.php
+++ b/src/Rule/NoAppConsole.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoAppConsole extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoAttributeRedundantParenthesis.php
+++ b/src/Rule/NoAttributeRedundantParenthesis.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure there is no redundant parenthesis on attribute')]
 #[InvalidExample('#[Bar()]')]
 #[ValidExample('#[Bar]')]

--- a/src/Rule/NoBashPrompt.php
+++ b/src/Rule/NoBashPrompt.php
@@ -23,9 +23,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure no bash prompt `$` is used before commands in `bash`, `shell` or `terminal` code blocks.')]
 #[InvalidExample('$ bin/console list')]
 #[ValidExample('bin/console list')]

--- a/src/Rule/NoBlankLineAfterFilepathInCodeBlock.php
+++ b/src/Rule/NoBlankLineAfterFilepathInCodeBlock.php
@@ -19,9 +19,6 @@ use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoBlankLineAfterFilepathInCodeBlock extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface

--- a/src/Rule/NoBlankLineAfterFilepathInPhpCodeBlock.php
+++ b/src/Rule/NoBlankLineAfterFilepathInPhpCodeBlock.php
@@ -21,9 +21,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoBlankLineAfterFilepathInPhpCodeBlock extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoBlankLineAfterFilepathInTwigCodeBlock.php
+++ b/src/Rule/NoBlankLineAfterFilepathInTwigCodeBlock.php
@@ -21,9 +21,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoBlankLineAfterFilepathInTwigCodeBlock extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoBlankLineAfterFilepathInXmlCodeBlock.php
+++ b/src/Rule/NoBlankLineAfterFilepathInXmlCodeBlock.php
@@ -21,9 +21,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoBlankLineAfterFilepathInXmlCodeBlock extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoBlankLineAfterFilepathInYamlCodeBlock.php
+++ b/src/Rule/NoBlankLineAfterFilepathInYamlCodeBlock.php
@@ -21,9 +21,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoBlankLineAfterFilepathInYamlCodeBlock extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoBracketsInMethodDirective.php
+++ b/src/Rule/NoBracketsInMethodDirective.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure a :method: directive has special format.')]
 #[InvalidExample(':method:`Symfony\\\\Component\\\\OptionsResolver\\\\Options::offsetGet()`')]
 #[ValidExample(':method:`Symfony\\\\Component\\\\OptionsResolver\\\\Options::offsetGet`')]

--- a/src/Rule/NoBrokenRefDirective.php
+++ b/src/Rule/NoBrokenRefDirective.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure only valid :ref: directives.')]
 #[InvalidExample('See this ref:`Foo`')]
 #[ValidExample('See this :ref:`Foo`')]

--- a/src/Rule/NoComposerPhar.php
+++ b/src/Rule/NoComposerPhar.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoComposerPhar extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoComposerReq.php
+++ b/src/Rule/NoComposerReq.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoComposerReq extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoConfigYaml.php
+++ b/src/Rule/NoConfigYaml.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoConfigYaml extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoContraction.php
+++ b/src/Rule/NoContraction.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure contractions are not used.')]
 #[InvalidExample("It's an example")]
 #[ValidExample('It is an example')]

--- a/src/Rule/NoDirectiveAfterShorthand.php
+++ b/src/Rule/NoDirectiveAfterShorthand.php
@@ -21,9 +21,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure that no directive follows the shorthand `::`. This could lead to broken markup.')]
 final class NoDirectiveAfterShorthand extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/NoDuplicateUseStatements.php
+++ b/src/Rule/NoDuplicateUseStatements.php
@@ -21,9 +21,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure there is not same use statement twice')]
 final class NoDuplicateUseStatements extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/NoEmptyLiterals.php
+++ b/src/Rule/NoEmptyLiterals.php
@@ -23,9 +23,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure that no empty literals are used.')]
 #[ValidExample('Please use ``foo``...')]
 #[InvalidExample('Please use ````...')]

--- a/src/Rule/NoExplicitUseOfCodeBlockPhp.php
+++ b/src/Rule/NoExplicitUseOfCodeBlockPhp.php
@@ -21,9 +21,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoExplicitUseOfCodeBlockPhp extends AbstractRule implements LineContentRule
 {
     use DirectiveTrait;

--- a/src/Rule/NoFootnotes.php
+++ b/src/Rule/NoFootnotes.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure there is no footnotes')]
 #[InvalidExample('.. [5] A numerical footnote. Note')]
 final class NoFootnotes extends AbstractRule implements LineContentRule

--- a/src/Rule/NoInheritdocInCodeExamples.php
+++ b/src/Rule/NoInheritdocInCodeExamples.php
@@ -20,9 +20,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoInheritdocInCodeExamples extends AbstractRule implements LineContentRule
 {
     use DirectiveTrait;

--- a/src/Rule/NoMergeConflict.php
+++ b/src/Rule/NoMergeConflict.php
@@ -20,9 +20,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure that the files does not contain merge conflicts.')]
 final class NoMergeConflict extends AbstractRule implements LineContentRule
 {

--- a/src/Rule/NoNamespaceAfterUseStatements.php
+++ b/src/Rule/NoNamespaceAfterUseStatements.php
@@ -20,9 +20,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoNamespaceAfterUseStatements extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoPhpOpenTagInCodeBlockPhpDirective.php
+++ b/src/Rule/NoPhpOpenTagInCodeBlockPhpDirective.php
@@ -20,9 +20,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoPhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoPhpPrefixBeforeBinConsole.php
+++ b/src/Rule/NoPhpPrefixBeforeBinConsole.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure `bin/console` is not prefixed with `php`.')]
 #[InvalidExample('php bin/console list')]
 #[ValidExample('bin/console list')]

--- a/src/Rule/NoPhpPrefixBeforeComposer.php
+++ b/src/Rule/NoPhpPrefixBeforeComposer.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoPhpPrefixBeforeComposer extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoSpaceBeforeSelfXmlClosingTag.php
+++ b/src/Rule/NoSpaceBeforeSelfXmlClosingTag.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class NoSpaceBeforeSelfXmlClosingTag extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/NoTypographicQuotes.php
+++ b/src/Rule/NoTypographicQuotes.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Do not use typographic quotes.')]
 #[ValidExample('Lorem \'ipsum\' dolor "sit amet"')]
 #[InvalidExample('Lorem ‘ipsum’ dolor “sit amet”')]

--- a/src/Rule/NonStaticPhpunitAssertions.php
+++ b/src/Rule/NonStaticPhpunitAssertions.php
@@ -23,9 +23,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Use `$this->assert*` over static calls.')]
 #[InvalidExample('self::assertTrue($foo);')]
 #[ValidExample('$this->assertTrue($foo);')]

--- a/src/Rule/OnlyBackslashesInNamespaceInPhpCodeBlock.php
+++ b/src/Rule/OnlyBackslashesInNamespaceInPhpCodeBlock.php
@@ -23,9 +23,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('A namespace declaration in a PHP code-block should only contain backslashes.')]
 #[InvalidExample('namespace Foo/Bar;')]
 #[ValidExample('namespace Foo\\Bar;')]

--- a/src/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlock.php
+++ b/src/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlock.php
@@ -23,9 +23,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('A use statement in a PHP code-block should only contain backslashes.')]
 #[InvalidExample('use Foo/Bar;')]
 #[ValidExample('use Foo\\Bar;')]

--- a/src/Rule/OrderedUseStatements.php
+++ b/src/Rule/OrderedUseStatements.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use Webmozart\Assert\Assert;
 use function Symfony\Component\String\u;
 
-/**
- * @no-named-arguments
- */
 final class OrderedUseStatements extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/PhpOpenTagInCodeBlockPhpDirective.php
+++ b/src/Rule/PhpOpenTagInCodeBlockPhpDirective.php
@@ -19,9 +19,6 @@ use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class PhpOpenTagInCodeBlockPhpDirective extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface

--- a/src/Rule/PhpPrefixBeforeBinConsole.php
+++ b/src/Rule/PhpPrefixBeforeBinConsole.php
@@ -23,9 +23,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure `bin/console` is prefixed with `php` to be safe executable on Microsoft Windows.')]
 #[InvalidExample('bin/console list')]
 #[ValidExample('php bin/console list')]

--- a/src/Rule/RemoveTrailingWhitespace.php
+++ b/src/Rule/RemoveTrailingWhitespace.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure there is not trailing whitespace.')]
 #[InvalidExample('Invalid sentence ')]
 #[ValidExample('Valid sentence')]

--- a/src/Rule/ReplaceCodeBlockTypes.php
+++ b/src/Rule/ReplaceCodeBlockTypes.php
@@ -21,9 +21,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Propose alternatives for disallowed code block types.')]
 final class ReplaceCodeBlockTypes extends CheckListRule implements LineContentRule
 {

--- a/src/Rule/Replacement.php
+++ b/src/Rule/Replacement.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class Replacement extends CheckListRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -16,9 +16,6 @@ namespace App\Rule;
 use App\Value\RuleGroup;
 use App\Value\RuleName;
 
-/**
- * @no-named-arguments
- */
 interface Rule
 {
     public static function getName(): RuleName;

--- a/src/Rule/ShortArraySyntax.php
+++ b/src/Rule/ShortArraySyntax.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class ShortArraySyntax extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/SpaceBeforeSelfXmlClosingTag.php
+++ b/src/Rule/SpaceBeforeSelfXmlClosingTag.php
@@ -19,9 +19,6 @@ use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class SpaceBeforeSelfXmlClosingTag extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface

--- a/src/Rule/SpaceBetweenLabelAndLinkInDoc.php
+++ b/src/Rule/SpaceBetweenLabelAndLinkInDoc.php
@@ -23,9 +23,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use function Symfony\Component\String\u;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure a space between label and link in :doc: directive.')]
 #[InvalidExample(':doc:`File</reference/constraints/File>`')]
 #[ValidExample(':doc:`File </reference/constraints/File>`')]

--- a/src/Rule/SpaceBetweenLabelAndLinkInRef.php
+++ b/src/Rule/SpaceBetweenLabelAndLinkInRef.php
@@ -23,9 +23,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use function Symfony\Component\String\u;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure a space between label and link in :ref: directive.')]
 #[InvalidExample(':ref:`receiving them via a worker<messenger-worker>`')]
 #[ValidExample(':ref:`receiving them via a worker <messenger-worker>`')]

--- a/src/Rule/StringReplacement.php
+++ b/src/Rule/StringReplacement.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class StringReplacement extends CheckListRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/TitleUnderlineLengthMustMatchTitleLength.php
+++ b/src/Rule/TitleUnderlineLengthMustMatchTitleLength.php
@@ -18,9 +18,6 @@ use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class TitleUnderlineLengthMustMatchTitleLength extends AbstractRule implements LineContentRule
 {
     public function check(Lines $lines, int $number, string $filename): ViolationInterface

--- a/src/Rule/Typo.php
+++ b/src/Rule/Typo.php
@@ -20,9 +20,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Report common typos.')]
 final class Typo extends CheckListRule implements LineContentRule
 {

--- a/src/Rule/UnusedLinks.php
+++ b/src/Rule/UnusedLinks.php
@@ -24,9 +24,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Report all links which are defined, but not used in the file anymore.')]
 final class UnusedLinks extends AbstractRule implements FileContentRule, ResetInterface
 {

--- a/src/Rule/UseDeprecatedDirectiveInsteadOfVersionadded.php
+++ b/src/Rule/UseDeprecatedDirectiveInsteadOfVersionadded.php
@@ -20,9 +20,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class UseDeprecatedDirectiveInsteadOfVersionadded extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/UseDoubleBackticksForInlineLiterals.php
+++ b/src/Rule/UseDoubleBackticksForInlineLiterals.php
@@ -24,9 +24,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure double backticks are used for inline literals instead of single backticks.')]
 #[ValidExample('Please use ``vector`` for this.')]
 #[ValidExample('See :ref:`my-reference` for details.')]

--- a/src/Rule/UseHttpsXsdUrls.php
+++ b/src/Rule/UseHttpsXsdUrls.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class UseHttpsXsdUrls extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/UseNamedConstructorWithoutNewKeywordRule.php
+++ b/src/Rule/UseNamedConstructorWithoutNewKeywordRule.php
@@ -22,9 +22,6 @@ use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensures that named constructor is used without "new" keyword.')]
 #[ValidExample('new Uuid()')]
 #[InvalidExample('new Uuid::fromString()')]

--- a/src/Rule/ValidInlineHighlightedNamespaces.php
+++ b/src/Rule/ValidInlineHighlightedNamespaces.php
@@ -23,9 +23,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensures to have 2 backslashes when highlighting a namespace to have valid output.')]
 #[ValidExample('``App\\Entity\\Foo``')]
 #[ValidExample('`App\\\\Entity\\\\Foo`')]

--- a/src/Rule/ValidUseStatements.php
+++ b/src/Rule/ValidUseStatements.php
@@ -19,9 +19,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 final class ValidUseStatements extends AbstractRule implements LineContentRule
 {
     public static function getGroups(): array

--- a/src/Rule/VersionaddedDirectiveMajorVersion.php
+++ b/src/Rule/VersionaddedDirectiveMajorVersion.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use Composer\Semver\VersionParser;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @no-named-arguments
- */
 final class VersionaddedDirectiveMajorVersion extends AbstractRule implements Configurable, LineContentRule
 {
     private int $majorVersion;

--- a/src/Rule/VersionaddedDirectiveMinVersion.php
+++ b/src/Rule/VersionaddedDirectiveMinVersion.php
@@ -21,9 +21,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @no-named-arguments
- */
 final class VersionaddedDirectiveMinVersion extends AbstractRule implements Configurable, LineContentRule
 {
     private string $minVersion;

--- a/src/Rule/VersionaddedDirectiveShouldHaveVersion.php
+++ b/src/Rule/VersionaddedDirectiveShouldHaveVersion.php
@@ -24,9 +24,6 @@ use App\Value\Violation;
 use App\Value\ViolationInterface;
 use Composer\Semver\VersionParser;
 
-/**
- * @no-named-arguments
- */
 #[Description('Ensure a versionadded directive has a version which follows SemVer.')]
 #[ValidExample('.. versionadded:: 3.4')]
 #[InvalidExample('.. versionadded::')]

--- a/src/Rule/YamlInsteadOfYmlSuffix.php
+++ b/src/Rule/YamlInsteadOfYmlSuffix.php
@@ -23,9 +23,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure to only use `yaml` instead of `yml`.')]
 #[ValidExample('.travis.yml')]
 #[ValidExample('..code-block:: yaml')]

--- a/src/Rule/YarnDevOptionAtTheEnd.php
+++ b/src/Rule/YarnDevOptionAtTheEnd.php
@@ -22,9 +22,6 @@ use App\Value\RuleGroup;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure yarn `--dev` option for `add` command is used at the end.')]
 #[InvalidExample('yarn add --dev jquery')]
 #[ValidExample('yarn add jquery --dev')]

--- a/src/Rule/YarnDevOptionNotAtTheEnd.php
+++ b/src/Rule/YarnDevOptionNotAtTheEnd.php
@@ -21,9 +21,6 @@ use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
 
-/**
- * @no-named-arguments
- */
 #[Description('Make sure yarn `--dev` option for `add` command is used at the end.')]
 #[ValidExample('yarn add --dev jquery')]
 #[InvalidExample('yarn add jquery --dev')]

--- a/src/Traits/DirectiveTrait.php
+++ b/src/Traits/DirectiveTrait.php
@@ -17,9 +17,6 @@ use App\Rst\RstParser;
 use App\Rst\Value\DirectiveContent;
 use App\Value\Lines;
 
-/**
- * @no-named-arguments
- */
 trait DirectiveTrait
 {
     public function getLineNumberOfDirective(string $directive, Lines $lines, int $number): int

--- a/src/Traits/ListTrait.php
+++ b/src/Traits/ListTrait.php
@@ -17,9 +17,6 @@ use App\Helper\PhpHelper;
 use App\Rst\RstParser;
 use App\Value\Lines;
 
-/**
- * @no-named-arguments
- */
 trait ListTrait
 {
     private function isPartOfListItem(Lines $lines, int $number): bool

--- a/src/Value/AnalyzerResult.php
+++ b/src/Value/AnalyzerResult.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Value;
 
-/**
- * @no-named-arguments
- */
 final class AnalyzerResult
 {
     /**

--- a/src/Value/ExcludedViolationList.php
+++ b/src/Value/ExcludedViolationList.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Value;
 
-/**
- * @no-named-arguments
- */
 final readonly class ExcludedViolationList
 {
     /**

--- a/src/Value/FileResult.php
+++ b/src/Value/FileResult.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Value;
 
-/**
- * @no-named-arguments
- */
 final readonly class FileResult
 {
     public function __construct(

--- a/src/Value/Line.php
+++ b/src/Value/Line.php
@@ -16,9 +16,6 @@ namespace App\Value;
 use Symfony\Component\String\UnicodeString;
 use function Symfony\Component\String\u;
 
-/**
- * @no-named-arguments
- */
 final class Line
 {
     private readonly UnicodeString $raw;

--- a/src/Value/Lines.php
+++ b/src/Value/Lines.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Value;
 
-/**
- * @no-named-arguments
- */
 final class Lines implements \SeekableIterator
 {
     private int $currentLine = 0;

--- a/src/Value/NullViolation.php
+++ b/src/Value/NullViolation.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Value;
 
-/**
- * @no-named-arguments
- */
 final readonly class NullViolation implements ViolationInterface
 {
     private string $message;

--- a/src/Value/RuleGroup.php
+++ b/src/Value/RuleGroup.php
@@ -15,9 +15,6 @@ namespace App\Value;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @no-named-arguments
- */
 final readonly class RuleGroup
 {
     private const string GROUP_EXPERIMENTAL = '@Experimental';

--- a/src/Value/RuleName.php
+++ b/src/Value/RuleName.php
@@ -16,9 +16,6 @@ namespace App\Value;
 use Webmozart\Assert\Assert;
 use function Symfony\Component\String\u;
 
-/**
- * @no-named-arguments
- */
 final readonly class RuleName
 {
     private string $name;

--- a/src/Value/RulesConfiguration.php
+++ b/src/Value/RulesConfiguration.php
@@ -15,9 +15,6 @@ namespace App\Value;
 
 use App\Rule\Rule;
 
-/**
- * @no-named-arguments
- */
 final class RulesConfiguration
 {
     /**

--- a/src/Value/Violation.php
+++ b/src/Value/Violation.php
@@ -15,9 +15,6 @@ namespace App\Value;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @no-named-arguments
- */
 final readonly class Violation implements ViolationInterface
 {
     private string $message;

--- a/src/Value/ViolationInterface.php
+++ b/src/Value/ViolationInterface.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace App\Value;
 
-/**
- * @no-named-arguments
- */
 interface ViolationInterface
 {
     public function message(): string;


### PR DESCRIPTION
## Summary
- Removes `@no-named-arguments` docblock annotations from 152 files
- The Ergebnis PHP-CS-Fixer config already has `phpdoc_tag_no_named_arguments` disabled, so these annotations won't be re-added

## Test plan
- [x] php-cs-fixer runs without re-adding annotations
- [x] All PHP files pass syntax check