### PR TITLE
Remove no-named-arguments attribute from codebase

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -25,6 +25,11 @@ file that was distributed with this source code.
 HEADER;
 
 $customRules = [
+    'general_phpdoc_annotation_remove' => [
+        'annotations' => [
+            'no-named-arguments',
+        ],
+    ],
     'no_trailing_whitespace_in_string' => false,
 ];
 

--- a/tests/Analyzer/FileCacheTest.php
+++ b/tests/Analyzer/FileCacheTest.php
@@ -21,9 +21,6 @@ use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class FileCacheTest extends UnitTestCase
 {
     private vfsStreamDirectory $root;

--- a/tests/Analyzer/MemoizingAnalyzerTest.php
+++ b/tests/Analyzer/MemoizingAnalyzerTest.php
@@ -21,9 +21,6 @@ use App\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
-/**
- * @no-named-arguments
- */
 final class MemoizingAnalyzerTest extends UnitTestCase
 {
     /**

--- a/tests/Analyzer/RstAnalyzerTest.php
+++ b/tests/Analyzer/RstAnalyzerTest.php
@@ -18,9 +18,6 @@ use App\Rule\MaxBlankLines;
 use App\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class RstAnalyzerTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Fixtures/Rule/DummyRule.php
+++ b/tests/Fixtures/Rule/DummyRule.php
@@ -16,9 +16,6 @@ namespace App\Tests\Fixtures\Rule;
 use App\Rule\AbstractRule;
 use App\Rule\Rule;
 
-/**
- * @no-named-arguments
- */
 final class DummyRule extends AbstractRule implements Rule
 {
 }

--- a/tests/Formatter/ConsoleFormatterTest.php
+++ b/tests/Formatter/ConsoleFormatterTest.php
@@ -24,9 +24,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-/**
- * @no-named-arguments
- */
 final class ConsoleFormatterTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Formatter/GithubFormatterTest.php
+++ b/tests/Formatter/GithubFormatterTest.php
@@ -25,9 +25,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-/**
- * @no-named-arguments
- */
 final class GithubFormatterTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Formatter/RegistryTest.php
+++ b/tests/Formatter/RegistryTest.php
@@ -19,9 +19,6 @@ use App\Formatter\Registry;
 use App\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class RegistryTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Helper/PhpHelperTest.php
+++ b/tests/Helper/PhpHelperTest.php
@@ -20,9 +20,6 @@ use App\Value\Line;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class PhpHelperTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Helper/TwigHelperTest.php
+++ b/tests/Helper/TwigHelperTest.php
@@ -19,9 +19,6 @@ use App\Value\Line;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class TwigHelperTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Helper/XmlHelperTest.php
+++ b/tests/Helper/XmlHelperTest.php
@@ -19,9 +19,6 @@ use App\Value\Line;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class XmlHelperTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Helper/YamlHelperTest.php
+++ b/tests/Helper/YamlHelperTest.php
@@ -19,9 +19,6 @@ use App\Value\Line;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class YamlHelperTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rst/RstParserTest.php
+++ b/tests/Rst/RstParserTest.php
@@ -19,9 +19,6 @@ use App\Value\Line;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class RstParserTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rst/Value/DirectiveContentTest.php
+++ b/tests/Rst/Value/DirectiveContentTest.php
@@ -18,9 +18,6 @@ use App\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 #[Group('temp')]
 final class DirectiveContentTest extends UnitTestCase
 {

--- a/tests/Rst/Value/LineTest.php
+++ b/tests/Rst/Value/LineTest.php
@@ -18,9 +18,6 @@ use App\Value\Line;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class LineTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rst/Value/LinkDefinitionTest.php
+++ b/tests/Rst/Value/LinkDefinitionTest.php
@@ -20,9 +20,6 @@ use App\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class LinkDefinitionTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rst/Value/LinkUsageTest.php
+++ b/tests/Rst/Value/LinkUsageTest.php
@@ -19,9 +19,6 @@ use App\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class LinkUsageTest extends UnitTestCase
 {
     #[Test]

--- a/tests/RstSample.php
+++ b/tests/RstSample.php
@@ -15,9 +15,6 @@ namespace App\Tests;
 
 use App\Value\Lines;
 
-/**
- * @no-named-arguments
- */
 final readonly class RstSample
 {
     public Lines $lines;

--- a/tests/Rule/AbstractLineContentRuleTestCase.php
+++ b/tests/Rule/AbstractLineContentRuleTestCase.php
@@ -20,9 +20,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 abstract class AbstractLineContentRuleTestCase extends UnitTestCase
 {
     abstract public function createRule(): LineContentRule;

--- a/tests/Rule/AmericanEnglishTest.php
+++ b/tests/Rule/AmericanEnglishTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class AmericanEnglishTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ArgumentVariableMustMatchTypeTest.php
+++ b/tests/Rule/ArgumentVariableMustMatchTypeTest.php
@@ -24,9 +24,6 @@ use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 
-/**
- * @no-named-arguments
- */
 final class ArgumentVariableMustMatchTypeTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/AvoidRepetetiveWordsTest.php
+++ b/tests/Rule/AvoidRepetetiveWordsTest.php
@@ -18,9 +18,6 @@ use App\Tests\RstSample;
 use App\Value\NullViolation;
 use App\Value\Violation;
 
-/**
- * @no-named-arguments
- */
 final class AvoidRepetetiveWordsTest extends AbstractLineContentRuleTestCase
 {
     public function createRule(): AvoidRepetetiveWords

--- a/tests/Rule/BlankLineAfterAnchorTest.php
+++ b/tests/Rule/BlankLineAfterAnchorTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class BlankLineAfterAnchorTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/BlankLineAfterColonTest.php
+++ b/tests/Rule/BlankLineAfterColonTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class BlankLineAfterColonTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/BlankLineAfterDirectiveTest.php
+++ b/tests/Rule/BlankLineAfterDirectiveTest.php
@@ -23,9 +23,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class BlankLineAfterDirectiveTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/BlankLineAfterFilepathInCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInCodeBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class BlankLineAfterFilepathInCodeBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/BlankLineAfterFilepathInPhpCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInPhpCodeBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class BlankLineAfterFilepathInPhpCodeBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/BlankLineAfterFilepathInTwigCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInTwigCodeBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class BlankLineAfterFilepathInTwigCodeBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/BlankLineAfterFilepathInXmlCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInXmlCodeBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class BlankLineAfterFilepathInXmlCodeBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/BlankLineAfterFilepathInYamlCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInYamlCodeBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class BlankLineAfterFilepathInYamlCodeBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/BlankLineBeforeDirectiveTest.php
+++ b/tests/Rule/BlankLineBeforeDirectiveTest.php
@@ -23,9 +23,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class BlankLineBeforeDirectiveTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ComposerDevOptionAtTheEndTest.php
+++ b/tests/Rule/ComposerDevOptionAtTheEndTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ComposerDevOptionAtTheEndTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ComposerDevOptionNotAtTheEndTest.php
+++ b/tests/Rule/ComposerDevOptionNotAtTheEndTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ComposerDevOptionNotAtTheEndTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/DeprecatedDirectiveMajorVersionTest.php
+++ b/tests/Rule/DeprecatedDirectiveMajorVersionTest.php
@@ -23,9 +23,6 @@ use Composer\Semver\VersionParser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class DeprecatedDirectiveMajorVersionTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/DeprecatedDirectiveMinVersionTest.php
+++ b/tests/Rule/DeprecatedDirectiveMinVersionTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class DeprecatedDirectiveMinVersionTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/DeprecatedDirectiveShouldHaveVersionTest.php
+++ b/tests/Rule/DeprecatedDirectiveShouldHaveVersionTest.php
@@ -23,9 +23,6 @@ use Composer\Semver\VersionParser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class DeprecatedDirectiveShouldHaveVersionTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/EnsureBashPromptBeforeComposerCommandTest.php
+++ b/tests/Rule/EnsureBashPromptBeforeComposerCommandTest.php
@@ -23,9 +23,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class EnsureBashPromptBeforeComposerCommandTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/EnsureClassConstantTest.php
+++ b/tests/Rule/EnsureClassConstantTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class EnsureClassConstantTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/EnsureCorrectFormatForPhpfunctionTest.php
+++ b/tests/Rule/EnsureCorrectFormatForPhpfunctionTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class EnsureCorrectFormatForPhpfunctionTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/EnsureExactlyOneSpaceBeforeDirectiveTypeTest.php
+++ b/tests/Rule/EnsureExactlyOneSpaceBeforeDirectiveTypeTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class EnsureExactlyOneSpaceBeforeDirectiveTypeTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest.php
+++ b/tests/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/EnsureExplicitNullableTypesTest.php
+++ b/tests/Rule/EnsureExplicitNullableTypesTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class EnsureExplicitNullableTypesTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/EnsureGithubDirectiveStartWithPrefixTest.php
+++ b/tests/Rule/EnsureGithubDirectiveStartWithPrefixTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class EnsureGithubDirectiveStartWithPrefixTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/EnsureLinkBottomTest.php
+++ b/tests/Rule/EnsureLinkBottomTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class EnsureLinkBottomTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/EnsureLinkDefinitionContainsValidUrlTest.php
+++ b/tests/Rule/EnsureLinkDefinitionContainsValidUrlTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class EnsureLinkDefinitionContainsValidUrlTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/EnsureOrderOfCodeBlocksInConfigurationBlockTest.php
+++ b/tests/Rule/EnsureOrderOfCodeBlocksInConfigurationBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class EnsureOrderOfCodeBlocksInConfigurationBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/EnsurePhpReferenceSyntaxTest.php
+++ b/tests/Rule/EnsurePhpReferenceSyntaxTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class EnsurePhpReferenceSyntaxTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ExtendAbstractAdminTest.php
+++ b/tests/Rule/ExtendAbstractAdminTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ExtendAbstractAdminTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ExtendAbstractControllerTest.php
+++ b/tests/Rule/ExtendAbstractControllerTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ExtendAbstractControllerTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ExtendControllerTest.php
+++ b/tests/Rule/ExtendControllerTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ExtendControllerTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ExtensionXlfInsteadOfXliffTest.php
+++ b/tests/Rule/ExtensionXlfInsteadOfXliffTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ExtensionXlfInsteadOfXliffTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/FilenameUsesDashesOnlyTest.php
+++ b/tests/Rule/FilenameUsesDashesOnlyTest.php
@@ -21,9 +21,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class FilenameUsesDashesOnlyTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/FilenameUsesUnderscoresOnlyTest.php
+++ b/tests/Rule/FilenameUsesUnderscoresOnlyTest.php
@@ -21,9 +21,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class FilenameUsesUnderscoresOnlyTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/FinalAdminClassesTest.php
+++ b/tests/Rule/FinalAdminClassesTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class FinalAdminClassesTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/FinalAdminExtensionClassesTest.php
+++ b/tests/Rule/FinalAdminExtensionClassesTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class FinalAdminExtensionClassesTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ForbiddenDirectivesTest.php
+++ b/tests/Rule/ForbiddenDirectivesTest.php
@@ -23,9 +23,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
-/**
- * @no-named-arguments
- */
 final class ForbiddenDirectivesTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/IndentionTest.php
+++ b/tests/Rule/IndentionTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class IndentionTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/KernelInsteadOfAppKernelTest.php
+++ b/tests/Rule/KernelInsteadOfAppKernelTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class KernelInsteadOfAppKernelTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/LineLengthTest.php
+++ b/tests/Rule/LineLengthTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class LineLengthTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/LowercaseAsInUseStatementTest.php
+++ b/tests/Rule/LowercaseAsInUseStatementTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class LowercaseAsInUseStatementTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/MaxBlankLinesTest.php
+++ b/tests/Rule/MaxBlankLinesTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class MaxBlankLinesTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/MaxColonsTest.php
+++ b/tests/Rule/MaxColonsTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class MaxColonsTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoAdminYamlTest.php
+++ b/tests/Rule/NoAdminYamlTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoAdminYamlTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoAttributeRedundantParenthesisTest.php
+++ b/tests/Rule/NoAttributeRedundantParenthesisTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoAttributeRedundantParenthesisTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoBashPromptTest.php
+++ b/tests/Rule/NoBashPromptTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoBashPromptTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoBlankLineAfterFilepathInCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInCodeBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoBlankLineAfterFilepathInCodeBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoBlankLineAfterFilepathInPhpCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInPhpCodeBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoBlankLineAfterFilepathInPhpCodeBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoBlankLineAfterFilepathInTwigCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInTwigCodeBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoBlankLineAfterFilepathInXmlCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInXmlCodeBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoBlankLineAfterFilepathInXmlCodeBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoBlankLineAfterFilepathInYamlCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInYamlCodeBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoBlankLineAfterFilepathInYamlCodeBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoBracketsInMethodDirectiveTest.php
+++ b/tests/Rule/NoBracketsInMethodDirectiveTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoBracketsInMethodDirectiveTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoBrokenRefDirectiveTest.php
+++ b/tests/Rule/NoBrokenRefDirectiveTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoBrokenRefDirectiveTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoComposerReqTest.php
+++ b/tests/Rule/NoComposerReqTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoComposerReqTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoContractionTest.php
+++ b/tests/Rule/NoContractionTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoContractionTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoDirectiveAfterShorthandTest.php
+++ b/tests/Rule/NoDirectiveAfterShorthandTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoDirectiveAfterShorthandTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoDuplicateUseStatementsTest.php
+++ b/tests/Rule/NoDuplicateUseStatementsTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoDuplicateUseStatementsTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoEmptyLiteralsTest.php
+++ b/tests/Rule/NoEmptyLiteralsTest.php
@@ -18,9 +18,6 @@ use App\Tests\RstSample;
 use App\Value\NullViolation;
 use App\Value\Violation;
 
-/**
- * @no-named-arguments
- */
 final class NoEmptyLiteralsTest extends AbstractLineContentRuleTestCase
 {
     public function createRule(): NoEmptyLiterals

--- a/tests/Rule/NoExplicitUseOfCodeBlockPhpTest.php
+++ b/tests/Rule/NoExplicitUseOfCodeBlockPhpTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoExplicitUseOfCodeBlockPhpTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoFootnotesTest.php
+++ b/tests/Rule/NoFootnotesTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoFootnotesTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoInheritdocInCodeExamplesTest.php
+++ b/tests/Rule/NoInheritdocInCodeExamplesTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoInheritdocInCodeExamplesTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoMergeConflictTest.php
+++ b/tests/Rule/NoMergeConflictTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoMergeConflictTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoNamespaceAfterUseStatementsTest.php
+++ b/tests/Rule/NoNamespaceAfterUseStatementsTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoNamespaceAfterUseStatementsTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoPhpOpenTagInCodeBlockPhpDirectiveTest.php
+++ b/tests/Rule/NoPhpOpenTagInCodeBlockPhpDirectiveTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoPhpOpenTagInCodeBlockPhpDirectiveTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoPhpPrefixBeforeBinConsoleTest.php
+++ b/tests/Rule/NoPhpPrefixBeforeBinConsoleTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoPhpPrefixBeforeBinConsoleTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoPhpPrefixBeforeComposerTest.php
+++ b/tests/Rule/NoPhpPrefixBeforeComposerTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoPhpPrefixBeforeComposerTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoSpaceBeforeSelfXmlClosingTagTest.php
+++ b/tests/Rule/NoSpaceBeforeSelfXmlClosingTagTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoSpaceBeforeSelfXmlClosingTagTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NoTypographicQuotesTest.php
+++ b/tests/Rule/NoTypographicQuotesTest.php
@@ -21,9 +21,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NoTypographicQuotesTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/NonStaticPhpunitAssertionsTest.php
+++ b/tests/Rule/NonStaticPhpunitAssertionsTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class NonStaticPhpunitAssertionsTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/OnlyBackslashesInNamespaceInPhpCodeBlockTest.php
+++ b/tests/Rule/OnlyBackslashesInNamespaceInPhpCodeBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class OnlyBackslashesInNamespaceInPhpCodeBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlockTest.php
+++ b/tests/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlockTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class OnlyBackslashesInUseStatementsInPhpCodeBlockTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/OrderedUseStatementsTest.php
+++ b/tests/Rule/OrderedUseStatementsTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class OrderedUseStatementsTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/PhpOpenTagInCodeBlockPhpDirectiveTest.php
+++ b/tests/Rule/PhpOpenTagInCodeBlockPhpDirectiveTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class PhpOpenTagInCodeBlockPhpDirectiveTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/PhpPrefixBeforeBinConsoleTest.php
+++ b/tests/Rule/PhpPrefixBeforeBinConsoleTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class PhpPrefixBeforeBinConsoleTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/RemoveTrailingWhitespaceTest.php
+++ b/tests/Rule/RemoveTrailingWhitespaceTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class RemoveTrailingWhitespaceTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ReplaceCodeBlockTypesTest.php
+++ b/tests/Rule/ReplaceCodeBlockTypesTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ReplaceCodeBlockTypesTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ReplacementTest.php
+++ b/tests/Rule/ReplacementTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ReplacementTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ShortArraySyntaxTest.php
+++ b/tests/Rule/ShortArraySyntaxTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ShortArraySyntaxTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/SpaceBeforeSelfXmlClosingTagTest.php
+++ b/tests/Rule/SpaceBeforeSelfXmlClosingTagTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class SpaceBeforeSelfXmlClosingTagTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/SpaceBetweenLabelAndLinkInDocTest.php
+++ b/tests/Rule/SpaceBetweenLabelAndLinkInDocTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class SpaceBetweenLabelAndLinkInDocTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/SpaceBetweenLabelAndLinkInRefTest.php
+++ b/tests/Rule/SpaceBetweenLabelAndLinkInRefTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class SpaceBetweenLabelAndLinkInRefTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/StringReplacementTest.php
+++ b/tests/Rule/StringReplacementTest.php
@@ -23,9 +23,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 #[Description('propose to replace a string with another string.')]
 final class StringReplacementTest extends UnitTestCase
 {

--- a/tests/Rule/TitleUnderlineLengthMustMatchTitleLengthTest.php
+++ b/tests/Rule/TitleUnderlineLengthMustMatchTitleLengthTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class TitleUnderlineLengthMustMatchTitleLengthTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/TypoTest.php
+++ b/tests/Rule/TypoTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class TypoTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/UnusedLinksTest.php
+++ b/tests/Rule/UnusedLinksTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class UnusedLinksTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/UseDeprecatedDirectiveInsteadOfVersionaddedTest.php
+++ b/tests/Rule/UseDeprecatedDirectiveInsteadOfVersionaddedTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class UseDeprecatedDirectiveInsteadOfVersionaddedTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/UseDoubleBackticksForInlineLiteralsTest.php
+++ b/tests/Rule/UseDoubleBackticksForInlineLiteralsTest.php
@@ -18,9 +18,6 @@ use App\Tests\RstSample;
 use App\Value\NullViolation;
 use App\Value\Violation;
 
-/**
- * @no-named-arguments
- */
 final class UseDoubleBackticksForInlineLiteralsTest extends AbstractLineContentRuleTestCase
 {
     public function createRule(): UseDoubleBackticksForInlineLiterals

--- a/tests/Rule/UseHttpsXsdUrlsTest.php
+++ b/tests/Rule/UseHttpsXsdUrlsTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class UseHttpsXsdUrlsTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
+++ b/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class UseNamedConstructorWithoutNewKeywordRuleTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ValidInlineHighlightedNamespacesTest.php
+++ b/tests/Rule/ValidInlineHighlightedNamespacesTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ValidInlineHighlightedNamespacesTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ValidUseStatementsTests.php
+++ b/tests/Rule/ValidUseStatementsTests.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ValidUseStatementsTests extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/VersionaddedDirectiveMajorVersionTest.php
+++ b/tests/Rule/VersionaddedDirectiveMajorVersionTest.php
@@ -23,9 +23,6 @@ use Composer\Semver\VersionParser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class VersionaddedDirectiveMajorVersionTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/VersionaddedDirectiveMinVersionTest.php
+++ b/tests/Rule/VersionaddedDirectiveMinVersionTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class VersionaddedDirectiveMinVersionTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/VersionaddedDirectiveShouldHaveVersionTest.php
+++ b/tests/Rule/VersionaddedDirectiveShouldHaveVersionTest.php
@@ -23,9 +23,6 @@ use Composer\Semver\VersionParser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class VersionaddedDirectiveShouldHaveVersionTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/YamlInsteadOfYmlSuffixTest.php
+++ b/tests/Rule/YamlInsteadOfYmlSuffixTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class YamlInsteadOfYmlSuffixTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/YarnDevOptionAtTheEndTest.php
+++ b/tests/Rule/YarnDevOptionAtTheEndTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class YarnDevOptionAtTheEndTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/YarnDevOptionNotAtTheEndTest.php
+++ b/tests/Rule/YarnDevOptionNotAtTheEndTest.php
@@ -22,9 +22,6 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class YarnDevOptionNotAtTheEndTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Traits/DirectiveTraitTest.php
+++ b/tests/Traits/DirectiveTraitTest.php
@@ -21,9 +21,6 @@ use App\Tests\Util\DirectiveTraitWrapper;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class DirectiveTraitTest extends UnitTestCase
 {
     private DirectiveTraitWrapper $traitWrapper;

--- a/tests/Traits/ListTraitTest.php
+++ b/tests/Traits/ListTraitTest.php
@@ -19,9 +19,6 @@ use App\Tests\Util\ListItemTraitWrapper;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ListTraitTest extends UnitTestCase
 {
     private ListItemTraitWrapper $traitWrapper;

--- a/tests/UnitTestCase.php
+++ b/tests/UnitTestCase.php
@@ -18,9 +18,6 @@ use Faker\Factory;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @no-named-arguments
- */
 abstract class UnitTestCase extends TestCase
 {
     /**

--- a/tests/Value/AnalyzerResultTest.php
+++ b/tests/Value/AnalyzerResultTest.php
@@ -20,9 +20,6 @@ use App\Value\FileResult;
 use App\Value\Violation;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class AnalyzerResultTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Value/ExcludedViolationListTest.php
+++ b/tests/Value/ExcludedViolationListTest.php
@@ -18,9 +18,6 @@ use App\Value\ExcludedViolationList;
 use App\Value\Violation;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class ExcludedViolationListTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Value/LinesTest.php
+++ b/tests/Value/LinesTest.php
@@ -17,9 +17,6 @@ use App\Tests\UnitTestCase;
 use App\Value\Lines;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class LinesTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Value/RuleGroupTest.php
+++ b/tests/Value/RuleGroupTest.php
@@ -20,9 +20,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class RuleGroupTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Value/RuleNameTest.php
+++ b/tests/Value/RuleNameTest.php
@@ -19,9 +19,6 @@ use Ergebnis\DataProvider\StringProvider;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class RuleNameTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Value/RulesConfigurationTest.php
+++ b/tests/Value/RulesConfigurationTest.php
@@ -18,9 +18,6 @@ use App\Tests\UnitTestCase;
 use App\Value\RulesConfiguration;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- * @no-named-arguments
- */
 final class RulesConfigurationTest extends UnitTestCase
 {
     #[Test]


### PR DESCRIPTION
Configure PHP-CS-Fixer to remove the @no-named-arguments PHPDoc annotation from all classes using the general_phpdoc_annotation_remove rule.