### PR TITLE
Update box.phar from 4.6.4 to 4.6.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD . /usr/src/app
 
 RUN composer install --classmap-authoritative --no-interaction --no-dev --optimize-autoloader
 
-ADD https://github.com/humbug/box/releases/download/4.6.4/box.phar ./box.phar
+ADD https://github.com/humbug/box/releases/download/4.6.10/box.phar ./box.phar
 RUN php box.phar compile
 
 FROM php:8.4-cli-alpine


### PR DESCRIPTION
## Summary
- Updates box.phar dependency from version 4.6.4 to 4.6.10

## Test plan
- Verify the Docker build completes successfully
- Ensure box.phar compiles the project without issues