### PR TITLE
Fix Docker multi-arch build and update Composer to `2.9.2`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM php:8.4-cli-alpine as build
+FROM php:8.4-cli-alpine AS build
 
-RUN apk add git # required for box to detect the version
-RUN apk add --update icu-dev && docker-php-ext-install -j$(nproc) intl # related to https://github.com/box-project/box/issues/516
+RUN apk add --no-cache git # required for box to detect the version
+RUN apk add --no-cache icu-dev && docker-php-ext-install -j$(nproc) intl # related to https://github.com/box-project/box/issues/516
 
-COPY --from=composer:2.8.5 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.9.2 /usr/bin/composer /usr/bin/composer
 
 WORKDIR /usr/src/app
 ADD . /usr/src/app


### PR DESCRIPTION
## Summary
- Fix Docker multi-arch build failure on ARM64 by using `--no-cache` flag for `apk` commands to avoid trigger issues under QEMU emulation
- Fix `FROM`/`AS` casing inconsistency warning
- Update Composer from `2.8.5` to `2.9.2`

## Test plan
- [ ] Verify the Docker multi-arch build completes successfully on both AMD64 and ARM64 architectures