### PR TITLE
Add QEMU setup for multi-arch Docker builds

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -32,6 +32,9 @@ jobs:
                 username: ${{ env.USERNAME }}
                 password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+
             - name: Set up Docker Buildx
               id: buildx
               uses: docker/setup-buildx-action@v3.11.1


### PR DESCRIPTION
## Summary
- Added `docker/setup-qemu-action@v3` before the buildx setup step to enable proper cross-platform emulation
- Fixes the multi-architecture Docker build failure where `apk add` was failing inside the QEMU emulator

## Test plan
- [ ] Verify the Docker build workflow succeeds for both `linux/amd64` and `linux/arm64` platforms