### PR TITLE
Skip EnsureAttributeBetweenBackticksInContent for :ref: directives

### DIFF
--- a/src/Rule/EnsureAttributeBetweenBackticksInContent.php
+++ b/src/Rule/EnsureAttributeBetweenBackticksInContent.php
@@ -44,6 +44,11 @@ final class EnsureAttributeBetweenBackticksInContent extends AbstractRule implem
         }
 
         if ($line->raw()->match('/(?<!`)#\[[^\]]*\](?!`)/')) {
+            // Skip if the attribute is inside a :ref: directive where backticks cannot be used
+            if ($line->raw()->match('/:ref:`[^`]*#\[[^\]]*\][^`]*`/')) {
+                return NullViolation::create();
+            }
+
             return Violation::from(
                 \sprintf('Please ensure to use backticks "%s"', $line->raw()->toString()),
                 $filename,

--- a/tests/Rule/EnsureAttributeBetweenBackticksInContentTest.php
+++ b/tests/Rule/EnsureAttributeBetweenBackticksInContentTest.php
@@ -69,5 +69,15 @@ final class EnsureAttributeBetweenBackticksInContentTest extends UnitTestCase
             NullViolation::create(),
             new RstSample('use ``#[MapEntity]`` attributes'),
         ];
+
+        yield 'No violation inside :ref: directive' => [
+            NullViolation::create(),
+            new RstSample(':ref:`the #[Route] attribute <routing-route-attributes>`'),
+        ];
+
+        yield 'No violation inside :ref: directive with multiple attributes' => [
+            NullViolation::create(),
+            new RstSample(':ref:`the #[Route] and #[Entity] attributes <some-reference>`'),
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- Fix false positive when PHP attributes like `#[Route]` appear inside `:ref:` directives
- Add check to skip violation when attribute is detected within a `:ref:` directive pattern
- Add tests for both single and multiple attributes inside `:ref:` directives

Fixes #2204

## Test plan
- [x] Verify existing tests still pass
- [x] Verify new test case for single attribute in `:ref:` directive passes
- [x] Verify new test case for multiple attributes in `:ref:` directive passes
- [x] Run PHPStan to ensure no static analysis errors