### PR TITLE
[NoExplicitUseOfCodeBlockPhp] Allow `.. code-block:: php` when previous paragraph ends with an RST link

### DIFF
--- a/src/Rule/NoExplicitUseOfCodeBlockPhp.php
+++ b/src/Rule/NoExplicitUseOfCodeBlockPhp.php
@@ -66,6 +66,7 @@ final class NoExplicitUseOfCodeBlockPhp extends AbstractRule implements LineCont
             if (self::directAfterHeadline($lines, $number)
                 || self::directAfterTable($lines, $number)
                 || self::previousParagraphEndsWithQuestionMark($lines, $number)
+                || self::previousParagraphEndsWithLink($lines, $number)
             ) {
                 return NullViolation::create();
             }
@@ -176,6 +177,27 @@ final class NoExplicitUseOfCodeBlockPhp extends AbstractRule implements LineCont
             }
 
             return (bool) preg_match('/\?$/', $lines->current()->clean()->toString());
+        }
+
+        return false;
+    }
+
+    private static function previousParagraphEndsWithLink(Lines $lines, int $number): bool
+    {
+        $lines->seek($number);
+
+        $i = $number;
+
+        while (1 <= $i) {
+            --$i;
+
+            $lines->seek($i);
+
+            if ($lines->current()->isBlank()) {
+                continue;
+            }
+
+            return (bool) preg_match('/`__?$/', $lines->current()->clean()->toString());
         }
 
         return false;

--- a/tests/Rule/NoExplicitUseOfCodeBlockPhpTest.php
+++ b/tests/Rule/NoExplicitUseOfCodeBlockPhpTest.php
@@ -562,6 +562,30 @@ RST
                 , 2),
         ];
 
+        yield 'valid because previous paragraph ends with a named link' => [
+            NullViolation::create(),
+            new RstSample(<<<'RST'
+**Required:** `Brave Search API key`_
+
+.. code-block:: php
+
+    $key = 'my-api-key';
+RST
+                , 2),
+        ];
+
+        yield 'valid because previous paragraph ends with an anonymous link' => [
+            NullViolation::create(),
+            new RstSample(<<<'RST'
+See the `official documentation`__
+
+.. code-block:: php
+
+    echo 'Hello World!';
+RST
+                , 2),
+        ];
+
         yield 'php code block following a configuration-block' => [
             NullViolation::create(),
             new RstSample(<<<'RST'


### PR DESCRIPTION
## Summary

- Adds a new `previousParagraphEndsWithLink` check to the `NoExplicitUseOfCodeBlockPhp` rule
- When a paragraph ends with an RST hyperlink reference (`` `text`_ `` or `` `text`__ ``), using `.. code-block:: php` is now allowed — the `::` shorthand cannot be appended to a link, making the explicit form necessary in this case
