### PR TITLE
Use PHP 8.4 in build stage as box.phar 4.6.10 is not yet compatible with PHP 8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5-cli-alpine AS build
+FROM php:8.4-cli-alpine AS build
 
 RUN apk add --no-cache git # required for box to detect the version
 RUN apk add --no-cache icu-dev && docker-php-ext-install -j$(nproc) intl # related to https://github.com/box-project/box/issues/516


### PR DESCRIPTION
## Summary

- `box.phar` 4.6.10 crashes on PHP 8.5 because PHP 8.5 turned the "using null as an array offset" deprecation into a fatal error (`RequirementsBuilder.php:29`)
- Use PHP 8.4 in the build stage only — box.phar needs it to compile the phar
- The runtime stage remains on PHP 8.5

Fixes https://github.com/OskarStark/doctor-rst/actions/runs/22223972511/job/64285940198