### PR TITLE
Add a no_standalone_syntax_element rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -79,6 +79,7 @@
 * [no_php_prefix_before_composer](#no_php_prefix_before_composer)
 * [no_relative_doc_path](#no_relative_doc_path)
 * [no_space_before_self_xml_closing_tag](#no_space_before_self_xml_closing_tag)
+* [no_standalone_syntax_element](#no_standalone_syntax_element)
 * [no_typographic_quotes](#no_typographic_quotes)
 * [non_static_phpunit_assertions](#non_static_phpunit_assertions)
 * [only_backslashes_in_namespace_in_php_code_block](#only_backslashes_in_namespace_in_php_code_block)
@@ -1398,6 +1399,43 @@ php bin/console list
 
 - Rule class: [App\Rule\NoSpaceBeforeSelfXmlClosingTag](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoSpaceBeforeSelfXmlClosingTag.php)
 - Test class: [App\Tests\Rule\NoSpaceBeforeSelfXmlClosingTagTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoSpaceBeforeSelfXmlClosingTagTest.php)
+
+## `no_standalone_syntax_element`
+
+  > _Make sure configured syntax elements are not used alone on a line, prefer the full declaration._
+
+#### Groups [`@Sonata`, `@Symfony`]
+
+#### Configuration options
+
+Name | Required | Allowed Types | Default
+--- | --- | --- | ---
+`elements` | `false` | `string[]` | `['::']`
+
+##### Valid Examples :+1:
+
+```rst
+The following example shows the usage:
+
+.. code-block:: php
+
+    $uuidFactory = new UuidFactory();
+```
+
+##### Invalid Examples :-1:
+
+```rst
+The following example shows the usage:
+
+::
+
+    $uuidFactory = new UuidFactory();
+```
+
+#### References
+
+- Rule class: [App\Rule\NoStandaloneSyntaxElement](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/NoStandaloneSyntaxElement.php)
+- Test class: [App\Tests\Rule\NoStandaloneSyntaxElementTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/NoStandaloneSyntaxElementTest.php)
 
 ## `no_typographic_quotes`
 

--- a/src/Command/RulesCommand.php
+++ b/src/Command/RulesCommand.php
@@ -152,7 +152,10 @@ class RulesCommand extends Command
                             $default = '';
                         } else {
                             if (\is_array($defaultValue)) {
-                                $defaultValue = '[]';
+                                $defaultValue = \sprintf('[%s]', implode(', ', array_map(
+                                    static fn (mixed $value): string => \is_string($value) ? \sprintf("'%s'", $value) : var_export($value, true),
+                                    $defaultValue,
+                                )));
                             }
 
                             /** @phpstan-ignore-next-line */

--- a/src/Rule/NoStandaloneSyntaxElement.php
+++ b/src/Rule/NoStandaloneSyntaxElement.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Rule;
+
+use App\Attribute\Rule\Description;
+use App\Attribute\Rule\InvalidExample;
+use App\Attribute\Rule\ValidExample;
+use App\Rst\RstParser;
+use App\Traits\DirectiveTrait;
+use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+#[Description('Make sure configured syntax elements are not used alone on a line, prefer the full declaration.')]
+#[InvalidExample(<<<'RST'
+The following example shows the usage:
+
+::
+
+    $uuidFactory = new UuidFactory();
+RST)]
+#[ValidExample(<<<'RST'
+The following example shows the usage:
+
+.. code-block:: php
+
+    $uuidFactory = new UuidFactory();
+RST)]
+final class NoStandaloneSyntaxElement extends AbstractRule implements Configurable, LineContentRule
+{
+    use DirectiveTrait;
+
+    /**
+     * @var string[]
+     */
+    private array $elements;
+
+    public function configureOptions(OptionsResolver $resolver): OptionsResolver
+    {
+        $resolver
+            ->setDefault('elements', ['::'])
+            ->setRequired('elements')
+            ->setAllowedTypes('elements', 'string[]');
+
+        return $resolver;
+    }
+
+    public function setOptions(array $options): void
+    {
+        $resolver = $this->configureOptions(new OptionsResolver());
+
+        $resolvedOptions = $resolver->resolve($options);
+
+        /** @phpstan-ignore-next-line */
+        $this->elements = $resolvedOptions['elements'];
+    }
+
+    public static function getGroups(): array
+    {
+        return [
+            RuleGroup::Sonata(),
+            RuleGroup::Symfony(),
+        ];
+    }
+
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
+    {
+        $lines->seek($number);
+        $line = $lines->current();
+
+        if ($line->isBlank()) {
+            return NullViolation::create();
+        }
+
+        $element = $line->clean()->toString();
+
+        if (!\in_array($element, $this->elements, true)) {
+            return NullViolation::create();
+        }
+
+        // the element may legitimately be part of the code being shown
+        if ($this->in(RstParser::DIRECTIVE_CODE_BLOCK, clone $lines, $number)) {
+            return NullViolation::create();
+        }
+
+        return Violation::from(
+            \sprintf('Please do not use "%s" alone on a line, prefer the full declaration.', $element),
+            $filename,
+            $number + 1,
+            $line,
+        );
+    }
+}

--- a/tests/Rule/NoStandaloneSyntaxElementTest.php
+++ b/tests/Rule/NoStandaloneSyntaxElementTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Rule;
+
+use App\Rule\LineContentRule;
+use App\Rule\NoStandaloneSyntaxElement;
+use App\Tests\RstSample;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class NoStandaloneSyntaxElementTest extends AbstractLineContentRuleTestCase
+{
+    public function createRule(): LineContentRule
+    {
+        $rule = new NoStandaloneSyntaxElement();
+        $rule->setOptions([]);
+
+        return $rule;
+    }
+
+    /**
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
+     */
+    public static function checkProvider(): iterable
+    {
+        yield 'shorthand alone on a line' => [
+            Violation::from(
+                'Please do not use "::" alone on a line, prefer the full declaration.',
+                'filename',
+                3,
+                '::',
+            ),
+            new RstSample(<<<'RST'
+The following example shows the usage:
+
+::
+
+    $uuidFactory = new UuidFactory();
+RST, 2),
+        ];
+
+        yield 'indented shorthand alone on a line' => [
+            Violation::from(
+                'Please do not use "::" alone on a line, prefer the full declaration.',
+                'filename',
+                3,
+                '::',
+            ),
+            new RstSample(<<<'RST'
+.. note::
+
+    ::
+
+        $uuidFactory = new UuidFactory();
+RST, 2),
+        ];
+
+        yield 'shorthand attached to a sentence' => [
+            NullViolation::create(),
+            new RstSample(<<<'RST'
+The following example shows the usage::
+
+    $uuidFactory = new UuidFactory();
+RST),
+        ];
+
+        yield 'explicit directive' => [
+            NullViolation::create(),
+            new RstSample(<<<'RST'
+.. code-block:: php
+
+    $uuidFactory = new UuidFactory();
+RST),
+        ];
+
+        yield 'blank line' => [
+            NullViolation::create(),
+            new RstSample(<<<'RST'
+The following example shows the usage::
+
+    $uuidFactory = new UuidFactory();
+RST, 1),
+        ];
+
+        yield 'inside a code block' => [
+            NullViolation::create(),
+            new RstSample(<<<'RST'
+.. code-block:: rst
+
+    ::
+
+        $uuidFactory = new UuidFactory();
+RST, 2),
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('checkWithConfiguredElementsProvider')]
+    public function checkWithConfiguredElements(ViolationInterface $expected, RstSample $sample): void
+    {
+        $rule = new NoStandaloneSyntaxElement();
+        $rule->setOptions(['elements' => ['..']]);
+
+        self::assertEquals(
+            $expected,
+            $rule->check($sample->lines, $sample->lineNumber, 'filename'),
+        );
+    }
+
+    /**
+     * @return \Generator<array{0: ViolationInterface, 1: RstSample}>
+     */
+    public static function checkWithConfiguredElementsProvider(): iterable
+    {
+        yield 'configured element alone on a line' => [
+            Violation::from(
+                'Please do not use ".." alone on a line, prefer the full declaration.',
+                'filename',
+                1,
+                '..',
+            ),
+            new RstSample('..'),
+        ];
+
+        yield 'default element is no longer reported' => [
+            NullViolation::create(),
+            new RstSample(<<<'RST'
+The following example shows the usage:
+
+::
+
+    $uuidFactory = new UuidFactory();
+RST, 2),
+        ];
+    }
+}


### PR DESCRIPTION
Fixes #2358

A line whose only content is `::` opens a literal block without saying what it holds. The Symfony docs prefer the full `.. code-block:: <language>` declaration, which is what the review linked from the issue asks for.

The rule reports such a line and takes the elements as an option, defaulting to `['::']`, so more can be added later without touching the code. Lines inside a `code-block` are skipped, since `::` may well be part of what the block is showing. It does not overlap with `ensure_shorthand_colons`, which only looks at lines ending with a single `:`, nor with `no_directive_after_shorthand`, which looks at what follows one.

I put it in both `@Sonata` and `@Symfony`, like the two neighbouring shorthand rules. Happy to drop Sonata if you would rather keep it to Symfony, you did not say on the issue.

## One thing I had to touch

`elements` is the first option in the project with a non-empty array default, and `RulesCommand` rendered any array default as a literal `[]`, which would have documented the rule as doing nothing out of the box. It now prints the contents, so `docs/rules.md` shows `['::']`. The three existing options whose default is an empty array still render as `[]`, unchanged in the regenerated file.

## Checks

2074 tests green on PHP 8.5 (the 8 PHPUnit notices are already there without this rule) and PHPStan is clean. `docs/rules.md` is regenerated.

PHP-CS-Fixer flags neither of the two new files. It does want to reformat 24 files I did not touch, including parts of `RulesCommand` far from my change, so something differs between my setup and yours there and I left all of it alone.
