### PR TITLE
Update box from 4.6.10 to 4.7.0 to fix the PHP 8.5 build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
                     composer-options: "--optimize-autoloader --no-dev"
 
             -   name: "Download humbug/box"
-                run: wget --no-clobber --output-document=./box https://github.com/humbug/box/releases/download/4.2.0/box.phar || true
+                run: wget --no-clobber --output-document=./box https://github.com/humbug/box/releases/download/4.7.0/box.phar || true
 
             -   name: "Make humbug/box executable"
                 run: chmod +x ./box

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD . /usr/src/app
 
 RUN composer install --classmap-authoritative --no-interaction --no-dev --optimize-autoloader
 
-ADD https://github.com/humbug/box/releases/download/4.6.10/box.phar ./box.phar
+ADD https://github.com/humbug/box/releases/download/4.7.0/box.phar ./box.phar
 RUN php box.phar compile
 
 FROM php:8.5-cli-alpine


### PR DESCRIPTION
## Summary

The docker build has been failing for every release since `1.78.1`, most recently for [`1.81.0`](https://github.com/OskarStark/doctor-rst/actions/runs/32973404322):

```
In RequirementsBuilder.php line 29:
  Using null as an array offset is deprecated, use an empty string instead
```

PHP 8.5 turned that deprecation into a fatal error. #2272 worked around it by pinning the build stage to PHP 8.4, but that was reverted in #2273 — so the build stayed broken.

box [`4.7.0`](https://github.com/box-project/box/releases/tag/4.7.0) ships exactly one change: *Add PHP 8.5 support*. `RequirementsBuilder::addRequiredExtension()` now casts the offset (`[(string) $source]`), which removes the need for any PHP version pin — both stages stay on `php:8.5-cli-alpine`.

The `Build` workflow is bumped from `4.2.0` to `4.7.0` as well, so both places use the same box version.

## Verification

Both paths were built locally on PHP 8.5:

- `docker build` succeeds, PHAR is 829 files / 1.01MB, `doctor-rst --version` reports the correct git version
- the `Build` workflow steps (composer install --no-dev, `box compile`, then all four `analyze dummy/` cache assertions) pass