### PR TITLE
composer: update all dependencies

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -216,16 +216,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.10",
+            "version": "v7.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57"
+                "reference": "696e12da8eea497a1a3808d714b43ff67a7df43e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57",
-                "reference": "d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57",
+                "url": "https://api.github.com/repos/symfony/config/zipball/696e12da8eea497a1a3808d714b43ff67a7df43e",
+                "reference": "696e12da8eea497a1a3808d714b43ff67a7df43e",
                 "shasum": ""
             },
             "require": {
@@ -271,7 +271,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.10"
+                "source": "https://github.com/symfony/config/tree/v7.4.17"
             },
             "funding": [
                 {
@@ -291,7 +291,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-03T14:20:49+00:00"
+            "time": "2026-08-20T09:55:18+00:00"
         },
         {
             "name": "symfony/console",
@@ -393,16 +393,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.10",
+            "version": "v7.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "4eb0d9dfa9d4f7c59216baf49b3ed6b1fb72293d"
+                "reference": "f318ac9da5aba0be2cf43ecdd562c05a33bc11c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/4eb0d9dfa9d4f7c59216baf49b3ed6b1fb72293d",
-                "reference": "4eb0d9dfa9d4f7c59216baf49b3ed6b1fb72293d",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f318ac9da5aba0be2cf43ecdd562c05a33bc11c0",
+                "reference": "f318ac9da5aba0be2cf43ecdd562c05a33bc11c0",
                 "shasum": ""
             },
             "require": {
@@ -453,7 +453,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.10"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.17"
             },
             "funding": [
                 {
@@ -473,7 +473,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-06T11:55:30+00:00"
+            "time": "2026-08-21T17:40:08+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -755,6 +755,93 @@
                 }
             ],
             "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/polyfill-deepclone",
+            "version": "v1.42.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-deepclone.git",
+                "reference": "70ba0627efc68e97ea392843458a2dd9d6dbd156"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-deepclone/zipball/70ba0627efc68e97ea392843458a2dd9d6dbd156",
+                "reference": "70ba0627efc68e97ea392843458a2dd9d6dbd156",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "provide": {
+                "ext-deepclone": "*"
+            },
+            "suggest": {
+                "ext-deepclone": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\DeepClone\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the deepclone extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "deepclone",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-deepclone/tree/v1.42.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-07T06:33:24+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -1188,20 +1275,22 @@
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v8.0.9",
+            "version": "v8.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "24cf67be4dd0926e4413635418682f4fff831412"
+                "reference": "b8f7dd85493e8372c7c81a1547caaaf86b9c16d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/24cf67be4dd0926e4413635418682f4fff831412",
-                "reference": "24cf67be4dd0926e4413635418682f4fff831412",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/b8f7dd85493e8372c7c81a1547caaaf86b9c16d1",
+                "reference": "b8f7dd85493e8372c7c81a1547caaaf86b9c16d1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-deepclone": "^1.40"
             },
             "require-dev": {
                 "symfony/property-access": "^7.4|^8.0",
@@ -1231,11 +1320,12 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "description": "Provides tools to export, instantiate, hydrate, clone and lazy-load PHP objects",
             "homepage": "https://symfony.com",
             "keywords": [
                 "clone",
                 "construct",
+                "deep-clone",
                 "export",
                 "hydrate",
                 "instantiate",
@@ -1244,7 +1334,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v8.0.9"
+                "source": "https://github.com/symfony/var-exporter/tree/v8.1.5"
             },
             "funding": [
                 {
@@ -1264,20 +1354,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:51:42+00:00"
+            "time": "2026-08-13T16:11:28+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.12",
+            "version": "v7.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "8b6952b56ca6417f25f7a65758cadd0ce02edc51"
+                "reference": "0b040d7b66ceb10b7bb24c8e6656257932693a12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/8b6952b56ca6417f25f7a65758cadd0ce02edc51",
-                "reference": "8b6952b56ca6417f25f7a65758cadd0ce02edc51",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0b040d7b66ceb10b7bb24c8e6656257932693a12",
+                "reference": "0b040d7b66ceb10b7bb24c8e6656257932693a12",
                 "shasum": ""
             },
             "require": {
@@ -1320,7 +1410,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.12"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.17"
             },
             "funding": [
                 {
@@ -1340,7 +1430,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:20:23+00:00"
+            "time": "2026-08-21T12:09:28+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2730,16 +2820,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.21",
+            "version": "v3.95.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "1228a1cd06e867846b5922a09d2ee948d8182e91"
+                "reference": "482722e0783c16325a07a998a0d9eda560f9be99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/1228a1cd06e867846b5922a09d2ee948d8182e91",
-                "reference": "1228a1cd06e867846b5922a09d2ee948d8182e91",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/482722e0783c16325a07a998a0d9eda560f9be99",
+                "reference": "482722e0783c16325a07a998a0d9eda560f9be99",
                 "shasum": ""
             },
             "require": {
@@ -2822,7 +2912,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.21"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.22"
             },
             "funding": [
                 {
@@ -2830,7 +2920,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-21T17:03:47+00:00"
+            "time": "2026-08-24T10:37:43+00:00"
         },
         {
             "name": "icanhazstring/composer-unused",
@@ -2935,19 +3025,20 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.8.2",
+            "version": "6.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76"
+                "reference": "7e420a943a6fbc95e60e3cf67acfbee85b3b4da7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/2c89ebb95ca9cedc9347f780333f7b25792dcb76",
-                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/7e420a943a6fbc95e60e3cf67acfbee85b3b4da7",
+                "reference": "7e420a943a6fbc95e60e3cf67acfbee85b3b4da7",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
                 "ext-json": "*",
                 "marc-mabe/php-enum": "^4.4",
                 "php": "^7.2 || ^8.0"
@@ -2980,20 +3071,9 @@
             ],
             "authors": [
                 {
-                    "name": "Bruno Prieto Reis",
-                    "email": "bruno.p.reis@gmail.com"
-                },
-                {
-                    "name": "Justin Rainbow",
-                    "email": "justin.rainbow@gmail.com"
-                },
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                },
-                {
-                    "name": "Robert Schönthal",
-                    "email": "seroscho@googlemail.com"
+                    "name": "Danny van der Sluijs",
+                    "email": "danny.vandersluijs@icloud.com",
+                    "role": "Maintainer"
                 }
             ],
             "description": "A library to validate a json schema.",
@@ -3004,9 +3084,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.8.2"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.11.0"
             },
-            "time": "2026-05-05T05:39:01+00:00"
+            "time": "2026-08-21T10:30:42+00:00"
         },
         {
             "name": "kubawerlos/php-cs-fixer-custom-fixers",
@@ -3328,20 +3408,20 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.4",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.0"
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
@@ -3376,32 +3456,31 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.14.0"
             },
             "funding": [
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
                 }
             ],
-            "time": "2025-08-01T08:46:24+00:00"
+            "time": "2026-08-11T10:17:44+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -3440,9 +3519,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3612,16 +3691,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
                 "shasum": ""
             },
             "require": {
@@ -3653,9 +3732,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
             },
-            "time": "2026-01-25T14:56:51+00:00"
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -3832,16 +3911,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.6",
+            "version": "12.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "876099a072646c7745f673d7aeab5382c4439691"
+                "reference": "186dab580576598076de6818596d12b61801880e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
-                "reference": "876099a072646c7745f673d7aeab5382c4439691",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/186dab580576598076de6818596d12b61801880e",
+                "reference": "186dab580576598076de6818596d12b61801880e",
                 "shasum": ""
             },
             "require": {
@@ -3852,13 +3931,13 @@
                 "php": ">=8.3",
                 "phpunit/php-text-template": "^5.0",
                 "sebastian/complexity": "^5.0",
-                "sebastian/environment": "^8.0.3",
-                "sebastian/lines-of-code": "^4.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/lines-of-code": "^4.0.1",
                 "sebastian/version": "^6.0",
                 "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.5.1"
+                "phpunit/phpunit": "^12.5.28"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -3896,7 +3975,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.7"
             },
             "funding": [
                 {
@@ -3916,27 +3995,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T08:23:17+00:00"
+            "time": "2026-06-01T13:24:19+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "6.0.1",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
+                "reference": "a248d1640ab059b075f53a2ef0f9856e864e06b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
-                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a248d1640ab059b075f53a2ef0f9856e864e06b5",
+                "reference": "a248d1640ab059b075f53a2ef0f9856e864e06b5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.33"
             },
             "type": "library",
             "extra": {
@@ -3969,7 +4048,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.2"
             },
             "funding": [
                 {
@@ -3989,7 +4068,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-02T14:04:18+00:00"
+            "time": "2026-08-25T14:40:53+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -4177,30 +4256,30 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.27",
+            "version": "12.5.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f37c01edaf3a0cd820331462506af93f1495696e"
+                "reference": "b98e028a26c5c5ba7e4a54be96ccf35f2914d184"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f37c01edaf3a0cd820331462506af93f1495696e",
-                "reference": "f37c01edaf3a0cd820331462506af93f1495696e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b98e028a26c5c5ba7e4a54be96ccf35f2914d184",
+                "reference": "b98e028a26c5c5ba7e4a54be96ccf35f2914d184",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.6",
+                "phpunit/php-code-coverage": "^12.5.7",
                 "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
@@ -4210,7 +4289,7 @@
                 "sebastian/diff": "^7.0.0",
                 "sebastian/environment": "^8.1.2",
                 "sebastian/exporter": "^7.0.3",
-                "sebastian/global-state": "^8.0.2",
+                "sebastian/global-state": "^8.0.3",
                 "sebastian/object-enumerator": "^7.0.0",
                 "sebastian/recursion-context": "^7.0.1",
                 "sebastian/type": "^6.0.4",
@@ -4255,7 +4334,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.27"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.33"
             },
             "funding": [
                 {
@@ -4263,7 +4342,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-25T15:35:34+00:00"
+            "time": "2026-07-28T13:58:09+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -5244,24 +5323,24 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "7.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
+                "reference": "cd4cabe39f8a4e8ee6818ba99f10a05561ea4ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/cd4cabe39f8a4e8ee6818ba99f10a05561ea4ad6",
+                "reference": "cd4cabe39f8a4e8ee6818ba99f10a05561ea4ad6",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0",
-                "symfony/process": "^7.2"
+                "phpunit/phpunit": "^12.5.33",
+                "symfony/process": "^7.4.17"
             },
             "type": "library",
             "extra": {
@@ -5299,15 +5378,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/diff",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:55:46+00:00"
+            "time": "2026-08-25T15:35:54+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -5477,26 +5568,26 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "8.0.2",
+            "version": "8.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
-                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b164d3274d6537ab462591c5755f76a8f5b1aae9",
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3",
                 "sebastian/object-reflector": "^5.0",
-                "sebastian/recursion-context": "^7.0"
+                "sebastian/recursion-context": "^7.0.1"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.28"
             },
             "type": "library",
             "extra": {
@@ -5527,7 +5618,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.3"
             },
             "funding": [
                 {
@@ -5547,7 +5638,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-29T11:29:25+00:00"
+            "time": "2026-06-01T15:10:33+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -6217,20 +6308,20 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v8.0.8",
+            "version": "v8.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "704c7808116fcdd67327db7b17de56b8ef6169e4"
+                "reference": "1a41232c678972b93ce499a504e19ea09dfcd0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/704c7808116fcdd67327db7b17de56b8ef6169e4",
-                "reference": "704c7808116fcdd67327db7b17de56b8ef6169e4",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/1a41232c678972b93ce499a504e19ea09dfcd0b2",
+                "reference": "1a41232c678972b93ce499a504e19ea09dfcd0b2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/property-info": "^7.4.4|^8.0.4"
             },
             "require-dev": {
@@ -6274,7 +6365,7 @@
                 "reflection"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-access/tree/v8.0.8"
+                "source": "https://github.com/symfony/property-access/tree/v8.1.4"
             },
             "funding": [
                 {
@@ -6294,24 +6385,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-07-30T12:40:56+00:00"
         },
         {
             "name": "symfony/property-info",
-            "version": "v8.0.8",
+            "version": "v8.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "c21711980653360d6ef5c26d0f9ca6f58a1135c6"
+                "reference": "b335f8e7fb1440ed3448fb33340efc6127678e53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/c21711980653360d6ef5c26d0f9ca6f58a1135c6",
-                "reference": "c21711980653360d6ef5c26d0f9ca6f58a1135c6",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/b335f8e7fb1440ed3448fb33340efc6127678e53",
+                "reference": "b335f8e7fb1440ed3448fb33340efc6127678e53",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/string": "^7.4|^8.0",
                 "symfony/type-info": "^7.4.7|^8.0.7"
             },
@@ -6360,7 +6451,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v8.0.8"
+                "source": "https://github.com/symfony/property-info/tree/v8.1.5"
             },
             "funding": [
                 {
@@ -6380,31 +6471,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-08-21T17:47:34+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v8.0.10",
+            "version": "v8.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "72ed7e1475790714f07c3a59bd01fd32cd022fdf"
+                "reference": "9c064d505c661e3e17aa8999870f4fb0ed05e024"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/72ed7e1475790714f07c3a59bd01fd32cd022fdf",
-                "reference": "72ed7e1475790714f07c3a59bd01fd32cd022fdf",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/9c064d505c661e3e17aa8999870f4fb0ed05e024",
+                "reference": "9c064d505c661e3e17aa8999870f4fb0ed05e024",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<5.2|>=7",
                 "phpdocumentor/type-resolver": "<1.5.1",
-                "symfony/property-access": "<7.4.2|>=8.0,<8.0.2",
-                "symfony/property-info": "<7.4",
+                "symfony/property-access": "<8.1",
+                "symfony/property-info": "<7.4.15",
                 "symfony/type-info": "<7.4"
             },
             "require-dev": {
@@ -6422,8 +6514,8 @@
                 "symfony/http-kernel": "^7.4|^8.0",
                 "symfony/messenger": "^7.4|^8.0",
                 "symfony/mime": "^7.4|^8.0",
-                "symfony/property-access": "^7.4.2|^8.0.2",
-                "symfony/property-info": "^7.4|^8.0",
+                "symfony/property-access": "^8.1",
+                "symfony/property-info": "^7.4.15|~8.0.15|^8.1.2",
                 "symfony/translation-contracts": "^2.5|^3",
                 "symfony/type-info": "^7.4|^8.0",
                 "symfony/uid": "^7.4|^8.0",
@@ -6458,7 +6550,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v8.0.10"
+                "source": "https://github.com/symfony/serializer/tree/v8.1.5"
             },
             "funding": [
                 {
@@ -6478,7 +6570,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-04T13:41:39+00:00"
+            "time": "2026-08-22T09:06:25+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -6548,20 +6640,20 @@
         },
         {
             "name": "symfony/type-info",
-            "version": "v8.0.9",
+            "version": "v8.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/type-info.git",
-                "reference": "08723aceb8c3271e8cb3db8b2565728b0c88e866"
+                "reference": "ceb48db5b38d6a48640c414be0c69d53980ae5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/type-info/zipball/08723aceb8c3271e8cb3db8b2565728b0c88e866",
-                "reference": "08723aceb8c3271e8cb3db8b2565728b0c88e866",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/ceb48db5b38d6a48640c414be0c69d53980ae5c5",
+                "reference": "ceb48db5b38d6a48640c414be0c69d53980ae5c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "psr/container": "^1.1|^2.0"
             },
             "conflict": {
@@ -6606,7 +6698,7 @@
                 "type"
             ],
             "support": {
-                "source": "https://github.com/symfony/type-info/tree/v8.0.9"
+                "source": "https://github.com/symfony/type-info/tree/v8.1.5"
             },
             "funding": [
                 {
@@ -6626,20 +6718,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T15:02:55+00:00"
+            "time": "2026-08-21T17:47:34+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.8",
+            "version": "v7.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd"
+                "reference": "53712df8727da1744490202eeb9cb50d4b95419d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
-                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/53712df8727da1744490202eeb9cb50d4b95419d",
+                "reference": "53712df8727da1744490202eeb9cb50d4b95419d",
                 "shasum": ""
             },
             "require": {
@@ -6655,7 +6747,7 @@
                 "symfony/http-kernel": "^6.4|^7.0|^8.0",
                 "symfony/process": "^6.4|^7.0|^8.0",
                 "symfony/uid": "^6.4|^7.0|^8.0",
-                "twig/twig": "^3.12"
+                "twig/twig": "^3.12|^4.0"
             },
             "bin": [
                 "Resources/bin/var-dump-server"
@@ -6693,7 +6785,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.8"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.17"
             },
             "funding": [
                 {
@@ -6713,7 +6805,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T13:44:50+00:00"
+            "time": "2026-08-21T12:09:28+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1880,6 +1880,7 @@ new Uuid::fromString()
 #### References
 
 - Rule class: [App\Rule\ValidUseStatements](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/ValidUseStatements.php)
+- Test class: [App\Tests\Rule\ValidUseStatementsTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/ValidUseStatementsTest.php)
 
 ## `versionadded_directive_major_version`
 

--- a/rector.php
+++ b/rector.php
@@ -13,22 +13,16 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Attribute\SortAttributeNamedArgsRector;
 use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector;
-use Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector;
 use Rector\CodeQuality\Rector\FuncCall\SortCallLikeNamedArgsRector;
 use Rector\CodeQuality\Rector\If_\CombineIfRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
-use Rector\EarlyReturn\Rector\If_\ChangeOrIfContinueToMultiContinueRector;
-use Rector\EarlyReturn\Rector\Return_\ReturnBinaryOrToEarlyReturnRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
-use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
-use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
-use Rector\Symfony\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector;
 
 return RectorConfig::configure()
     ->withParallel()
@@ -61,8 +55,6 @@ return RectorConfig::configure()
     ->withSkip([
         SortAttributeNamedArgsRector::class,
         SortCallLikeNamedArgsRector::class,
-        ControllerMethodInjectionToConstructorRector::class, // Route parameters should stay as action parameters, not constructor
-        SimplifyRegexPatternRector::class, // Keep explicit regex patterns for better readability
         RemoveUnusedPublicMethodParameterRector::class => [
             __DIR__.'/src/EventListener', // Keep event args in listeners for consistency
         ],
@@ -73,13 +65,9 @@ return RectorConfig::configure()
         LocallyCalledStaticMethodToNonStaticRector::class,
         PreferPHPUnitThisCallRector::class,
         NullToStrictStringFuncCallArgRector::class, // Avoid redundant casts when value is already a string
-        ReturnBinaryOrToEarlyReturnRector::class, // Keep combined conditions readable instead of splitting into multiple returns
-        ChangeOrIfContinueToMultiContinueRector::class, // Keep combined conditions with continue readable
         CombineIfRector::class, // Keep nested ifs for better readability
         RecastingRemovalRector::class, // Keep explicit casts for clarity
-        DisallowedEmptyRuleFixerRector::class, // Keep empty() for readability
     ])
     ->withRules([
         PreferPHPUnitSelfCallRector::class,
-        StaticDataProviderClassMethodRector::class,
     ]);

--- a/src/Analyzer/FileCache.php
+++ b/src/Analyzer/FileCache.php
@@ -121,12 +121,10 @@ final class FileCache implements Cache
 
         file_put_contents(
             $this->cacheFile,
-            serialize(
-                [
-                    'version' => Application::VERSION,
-                    'payload' => $cache,
-                ],
-            ),
+            serialize([
+                'version' => Application::VERSION,
+                'payload' => $cache,
+            ],),
         );
     }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -67,7 +67,7 @@ class Application extends BaseApplication
             $fileLoader->load('cache.php');
         }
 
-        $container->compile();
+        $container->compile(true);
 
         return $container;
     }

--- a/src/Attribute/Rule/Description.php
+++ b/src/Attribute/Rule/Description.php
@@ -16,8 +16,7 @@ namespace App\Attribute\Rule;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class Description
 {
-    public function __construct(
-        public readonly string $value,
-    ) {
+    public function __construct(public readonly string $value)
+    {
     }
 }

--- a/src/Attribute/Rule/InvalidExample.php
+++ b/src/Attribute/Rule/InvalidExample.php
@@ -16,8 +16,7 @@ namespace App\Attribute\Rule;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class InvalidExample
 {
-    public function __construct(
-        public readonly string $value,
-    ) {
+    public function __construct(public readonly string $value)
+    {
     }
 }

--- a/src/Attribute/Rule/ValidExample.php
+++ b/src/Attribute/Rule/ValidExample.php
@@ -16,8 +16,7 @@ namespace App\Attribute\Rule;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class ValidExample
 {
-    public function __construct(
-        public readonly string $value,
-    ) {
+    public function __construct(public readonly string $value)
+    {
     }
 }

--- a/src/Command/RulesCommand.php
+++ b/src/Command/RulesCommand.php
@@ -251,12 +251,10 @@ class RulesCommand extends Command
             $classShortName,
         );
         $ruleLink = self::renderGithubLink($className, $classPath);
-        $this->io->writeln(
-            \sprintf(
-                '- Rule class: %s',
-                $ruleLink,
-            ),
-        );
+        $this->io->writeln(\sprintf(
+            '- Rule class: %s',
+            $ruleLink,
+        ),);
 
         $testName = \sprintf(
             'App\Tests\Rule\\%sTest',
@@ -269,12 +267,10 @@ class RulesCommand extends Command
                 $classShortName,
             );
             $testLink = self::renderGithubLink($testName, $testPath);
-            $this->io->writeln(
-                \sprintf(
-                    '- Test class: %s',
-                    $testLink,
-                ),
-            );
+            $this->io->writeln(\sprintf(
+                '- Test class: %s',
+                $testLink,
+            ),);
         }
 
         $this->io->newLine();

--- a/src/Formatter/GithubFormatter.php
+++ b/src/Formatter/GithubFormatter.php
@@ -18,9 +18,8 @@ use Symfony\Component\Console\Style\OutputStyle;
 
 class GithubFormatter implements Formatter
 {
-    public function __construct(
-        private readonly ConsoleFormatter $consoleFormatter,
-    ) {
+    public function __construct(private readonly ConsoleFormatter $consoleFormatter)
+    {
     }
 
     public function format(OutputStyle $style, AnalyzerResult $analyzerResult, string $analyzeDir, bool $showValidFiles): void

--- a/src/Helper/XmlHelper.php
+++ b/src/Helper/XmlHelper.php
@@ -32,9 +32,7 @@ final class XmlHelper
         } elseif (preg_match('/^<!--(.*)/', $string)
             && (
                 ($closed && preg_match('/(.*)-->$/', $string))
-                || (
-                    !$closed && !preg_match('/(.*)-->$/', $string)
-                )
+                || (!$closed && !preg_match('/(.*)-->$/', $string))
             )) {
             return true;
         }

--- a/src/Rst/RstParser.php
+++ b/src/Rst/RstParser.php
@@ -105,17 +105,12 @@ class RstParser
 
     public static function isPhpDirective(Line $line): bool
     {
-        if ($line->isDefaultDirective()
+        return $line->isDefaultDirective()
             || self::codeBlockDirectiveIsTypeOf($line, self::CODE_BLOCK_PHP, true)
             || self::codeBlockDirectiveIsTypeOf($line, self::CODE_BLOCK_PHP_ANNOTATIONS, true)
             || self::codeBlockDirectiveIsTypeOf($line, self::CODE_BLOCK_PHP_ATTRIBUTES, true)
             || self::codeBlockDirectiveIsTypeOf($line, self::CODE_BLOCK_PHP_SYMFONY, true)
-            || self::codeBlockDirectiveIsTypeOf($line, self::CODE_BLOCK_PHP_STANDALONE, true)
-        ) {
-            return true;
-        }
-
-        return false;
+            || self::codeBlockDirectiveIsTypeOf($line, self::CODE_BLOCK_PHP_STANDALONE, true);
     }
 
     public static function directiveIs(Line $line, string $directive, ?bool $strict = false): bool
@@ -134,13 +129,7 @@ class RstParser
             $directivesExcludedCodeBlock = array_diff(self::DIRECTIVES, [$directive]);
             $rawLine = $line->raw()->toString();
 
-            foreach ($directivesExcludedCodeBlock as $other) {
-                if (str_contains($rawLine, $other)) {
-                    return false;
-                }
-            }
-
-            return true;
+            return array_all($directivesExcludedCodeBlock, static fn ($other) => !str_contains($rawLine, $other));
         }
 
         return false;
@@ -194,11 +183,7 @@ class RstParser
                 return true;
             }
 
-            if (($matches = $line->clean()->match('/\:\: (.*)$/')) && $type === $matches[1]) {
-                return true;
-            }
-
-            return false;
+            return ($matches = $line->clean()->match('/\:\: (.*)$/')) && $type === $matches[1];
         }
 
         return false;
@@ -236,9 +221,7 @@ class RstParser
             && '.' === $string[1]
             && ' ' === $string[2]
             && '[' === $string[3]
-            && [] !== $line->clean()->match(
-                '/^\.\. \[[0-9]\]/',
-            );
+            && [] !== $line->clean()->match('/^\.\. \[[0-9]\]/');
     }
 
     /**

--- a/src/Rst/Value/DirectiveContent.php
+++ b/src/Rst/Value/DirectiveContent.php
@@ -15,11 +15,10 @@ namespace App\Rst\Value;
 
 final class DirectiveContent
 {
-    public array $cleaned = [];
+    public array $cleaned;
 
-    public function __construct(
-        public readonly array $raw,
-    ) {
+    public function __construct(public readonly array $raw)
+    {
         $cleaned = [];
 
         // remove entries in the array which equals an empty string, but only at the start and at the end

--- a/src/Rst/Value/LinkUsage.php
+++ b/src/Rst/Value/LinkUsage.php
@@ -17,9 +17,8 @@ use Webmozart\Assert\Assert;
 
 final readonly class LinkUsage
 {
-    private function __construct(
-        private LinkName $name,
-    ) {
+    private function __construct(private LinkName $name)
+    {
     }
 
     public static function fromLine(string $line): self

--- a/src/Rule/CheckListRule.php
+++ b/src/Rule/CheckListRule.php
@@ -18,10 +18,7 @@ abstract class CheckListRule extends AbstractRule
     public string $search;
     public string $message;
 
-    /**
-     * @return static
-     */
-    public function configure(string $pattern, ?string $message): self
+    public function configure(string $pattern, ?string $message): static
     {
         $this->search = $pattern;
         $this->message = $message ?? static::getDefaultMessage();

--- a/src/Rule/DeprecatedDirectiveMajorVersion.php
+++ b/src/Rule/DeprecatedDirectiveMajorVersion.php
@@ -26,9 +26,8 @@ final class DeprecatedDirectiveMajorVersion extends AbstractRule implements Conf
 {
     private int $majorVersion;
 
-    public function __construct(
-        private readonly VersionParser $versionParser,
-    ) {
+    public function __construct(private readonly VersionParser $versionParser)
+    {
     }
 
     public function configureOptions(OptionsResolver $resolver): OptionsResolver

--- a/src/Rule/DeprecatedDirectiveShouldHaveVersion.php
+++ b/src/Rule/DeprecatedDirectiveShouldHaveVersion.php
@@ -30,9 +30,8 @@ use Composer\Semver\VersionParser;
 #[InvalidExample('.. deprecated:: foo-bar')]
 final class DeprecatedDirectiveShouldHaveVersion extends AbstractRule implements LineContentRule
 {
-    public function __construct(
-        private readonly VersionParser $versionParser,
-    ) {
+    public function __construct(private readonly VersionParser $versionParser)
+    {
     }
 
     public static function getGroups(): array

--- a/src/Rule/NoExplicitUseOfCodeBlockPhp.php
+++ b/src/Rule/NoExplicitUseOfCodeBlockPhp.php
@@ -28,7 +28,7 @@ final class NoExplicitUseOfCodeBlockPhp extends AbstractRule implements LineCont
     /**
      * @var string[]
      */
-    final public const array ALLOWED_PREVIOUS_DIRECTIVES = [
+    public const array ALLOWED_PREVIOUS_DIRECTIVES = [
         RstParser::DIRECTIVE_CAUTION,
         RstParser::DIRECTIVE_CONFIGURATION_BLOCK,
         RstParser::DIRECTIVE_DEPRECATED,

--- a/src/Rule/VersionaddedDirectiveMajorVersion.php
+++ b/src/Rule/VersionaddedDirectiveMajorVersion.php
@@ -26,9 +26,8 @@ final class VersionaddedDirectiveMajorVersion extends AbstractRule implements Co
 {
     private int $majorVersion;
 
-    public function __construct(
-        private readonly VersionParser $versionParser,
-    ) {
+    public function __construct(private readonly VersionParser $versionParser)
+    {
     }
 
     public function configureOptions(OptionsResolver $resolver): OptionsResolver

--- a/src/Rule/VersionaddedDirectiveShouldHaveVersion.php
+++ b/src/Rule/VersionaddedDirectiveShouldHaveVersion.php
@@ -30,9 +30,8 @@ use Composer\Semver\VersionParser;
 #[InvalidExample('.. versionadded:: foo-bar')]
 final class VersionaddedDirectiveShouldHaveVersion extends AbstractRule implements LineContentRule
 {
-    public function __construct(
-        private readonly VersionParser $versionParser,
-    ) {
+    public function __construct(private readonly VersionParser $versionParser)
+    {
     }
 
     public static function getGroups(): array

--- a/src/Value/Lines.php
+++ b/src/Value/Lines.php
@@ -20,9 +20,8 @@ final class Lines implements \SeekableIterator
     /**
      * @param Line[] $array
      */
-    private function __construct(
-        private array $array,
-    ) {
+    private function __construct(private array $array)
+    {
     }
 
     public function __clone()

--- a/src/Value/RuleName.php
+++ b/src/Value/RuleName.php
@@ -37,9 +37,7 @@ final readonly class RuleName
         Assert::stringNotEmpty($class);
         Assert::notWhitespaceOnly($class);
 
-        return self::fromString(
-            u(substr((string) strrchr($class, '\\'), 1))->snake()->toString(),
-        );
+        return self::fromString(u(substr((string) strrchr($class, '\\'), 1))->snake()->toString());
     }
 
     public static function fromString(string $value): self

--- a/tests/Analyzer/FileCacheTest.php
+++ b/tests/Analyzer/FileCacheTest.php
@@ -52,18 +52,16 @@ final class FileCacheTest extends UnitTestCase
             ->withContent('')
             ->at($this->root);
 
-        $content = serialize(
-            [
-                'version' => Application::VERSION,
-                'payload' => [
-                    $rstFile->url() => [
-                        'hash' => sha1_file($rstFile->url()),
-                        'rules' => sha1(serialize($rules)),
-                        'violations' => [],
-                    ],
+        $content = serialize([
+            'version' => Application::VERSION,
+            'payload' => [
+                $rstFile->url() => [
+                    'hash' => sha1_file($rstFile->url()),
+                    'rules' => sha1(serialize($rules)),
+                    'violations' => [],
                 ],
             ],
-        );
+        ],);
         $cacheFile = vfsStream::newFile('.doctor-rst.cache')
             ->withContent($content)
             ->at($this->root);
@@ -97,18 +95,16 @@ final class FileCacheTest extends UnitTestCase
             ->withContent('')
             ->at($this->root);
 
-        $content = serialize(
-            [
-                'version' => Application::VERSION,
-                'payload' => [
-                    $rstFile->url() => [
-                        'hash' => 'test',
-                        'rules' => sha1(serialize($rules)),
-                        'violations' => [],
-                    ],
+        $content = serialize([
+            'version' => Application::VERSION,
+            'payload' => [
+                $rstFile->url() => [
+                    'hash' => 'test',
+                    'rules' => sha1(serialize($rules)),
+                    'violations' => [],
                 ],
             ],
-        );
+        ],);
         $cacheFile = vfsStream::newFile('.doctor-rst.cache')
             ->withContent($content)
             ->at($this->root);
@@ -126,18 +122,16 @@ final class FileCacheTest extends UnitTestCase
             ->withContent('')
             ->at($this->root);
 
-        $content = serialize(
-            [
-                'version' => Application::VERSION,
-                'payload' => [
-                    $rstFile->url() => [
-                        'hash' => sha1_file($rstFile->url()),
-                        'rules' => 'test',
-                        'violations' => [],
-                    ],
+        $content = serialize([
+            'version' => Application::VERSION,
+            'payload' => [
+                $rstFile->url() => [
+                    'hash' => sha1_file($rstFile->url()),
+                    'rules' => 'test',
+                    'violations' => [],
                 ],
             ],
-        );
+        ],);
         $cacheFile = vfsStream::newFile('.doctor-rst.cache')
             ->withContent($content)
             ->at($this->root);
@@ -150,18 +144,16 @@ final class FileCacheTest extends UnitTestCase
     #[Test]
     public function unparsedFilesWillDeletedFromCacheFile(): void
     {
-        $content = serialize(
-            [
-                'version' => Application::VERSION,
-                'payload' => [
-                    'doc.rst' => [
-                        'hash' => 'test',
-                        'rules' => 'test',
-                        'violations' => [],
-                    ],
+        $content = serialize([
+            'version' => Application::VERSION,
+            'payload' => [
+                'doc.rst' => [
+                    'hash' => 'test',
+                    'rules' => 'test',
+                    'violations' => [],
                 ],
             ],
-        );
+        ],);
         $cacheFile = vfsStream::newFile('.doctor-rst.cache')
             ->withContent($content)
             ->at($this->root);

--- a/tests/Analyzer/MemoizingAnalyzerTest.php
+++ b/tests/Analyzer/MemoizingAnalyzerTest.php
@@ -24,12 +24,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 final class MemoizingAnalyzerTest extends UnitTestCase
 {
     /**
-     * @var Analyzer|MockObject
+     * @var Analyzer&MockObject
      */
     private MockObject $analyzer;
 
     /**
-     * @var Cache|MockObject
+     * @var Cache&MockObject
      */
     private MockObject $cache;
     private MemoizingAnalyzer $memoizingAnalyzer;

--- a/tests/Rule/ArgumentVariableMustMatchTypeTest.php
+++ b/tests/Rule/ArgumentVariableMustMatchTypeTest.php
@@ -146,9 +146,7 @@ final class ArgumentVariableMustMatchTypeTest extends UnitTestCase
     #[Test]
     public function invalidOptionType(): void
     {
-        $this->expectExceptionObject(
-            new InvalidOptionsException('The nested option "arguments" with value "foo" is expected to be of type array, but is of type "string".'),
-        );
+        $this->expectExceptionObject(new InvalidOptionsException('The nested option "arguments" with value "foo" is expected to be of type array, but is of type "string".'));
 
         $rule = new ArgumentVariableMustMatchType();
         $rule->setOptions([
@@ -159,9 +157,7 @@ final class ArgumentVariableMustMatchTypeTest extends UnitTestCase
     #[Test]
     public function invalidOptionValue(): void
     {
-        $this->expectExceptionObject(
-            new UndefinedOptionsException('The option "arguments[0][foo]" does not exist. Defined options are: "name", "type".'),
-        );
+        $this->expectExceptionObject(new UndefinedOptionsException('The option "arguments[0][foo]" does not exist. Defined options are: "name", "type".'));
 
         $rule = new ArgumentVariableMustMatchType();
         $rule->setOptions([

--- a/tests/Rule/BlankLineAfterDirectiveTest.php
+++ b/tests/Rule/BlankLineAfterDirectiveTest.php
@@ -89,15 +89,13 @@ final class BlankLineAfterDirectiveTest extends UnitTestCase
 
         yield [
             NullViolation::create(),
-            new RstSample(
-                <<<'SAMPLE'
+            new RstSample(<<<'SAMPLE'
 .. code-block:: text
     :caption: src/app.js
     :emphasize-lines: 3,11
 
     import {h, render} from 'preact';
-SAMPLE
-            ),
+SAMPLE),
         ];
 
         yield [

--- a/tests/Rule/BlankLineAfterFilepathInPhpCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInPhpCodeBlockTest.php
@@ -47,53 +47,45 @@ final class BlankLineAfterFilepathInPhpCodeBlockTest extends UnitTestCase
                     3,
                     '// src/Handler/Collection.php',
                 ),
-                new RstSample(
-                    [
-                        $codeBlock,
-                        '',
-                        '    // src/Handler/Collection.php',
-                        '    namespace App\\Handler;',
-                    ],
-                ),
+                new RstSample([
+                    $codeBlock,
+                    '',
+                    '    // src/Handler/Collection.php',
+                    '    namespace App\\Handler;',
+                ], ),
             ];
 
             yield [
                 NullViolation::create(),
-                new RstSample(
-                    [
-                        $codeBlock,
-                        '',
-                        '    // src/Handler/Collection.php',
-                        '',
-                        '    namespace App\\Handler;',
-                    ],
-                ),
+                new RstSample([
+                    $codeBlock,
+                    '',
+                    '    // src/Handler/Collection.php',
+                    '',
+                    '    namespace App\\Handler;',
+                ], ),
             ];
 
             yield [
                 NullViolation::create(),
-                new RstSample(
-                    [
-                        $codeBlock,
-                        '',
-                        '    // src/Handler/Collection.php',
-                        '    // a comment',
-                        '    namespace App\\Handler;',
-                    ],
-                ),
+                new RstSample([
+                    $codeBlock,
+                    '',
+                    '    // src/Handler/Collection.php',
+                    '    // a comment',
+                    '    namespace App\\Handler;',
+                ], ),
             ];
 
             yield [
                 NullViolation::create(),
-                new RstSample(
-                    [
-                        $codeBlock,
-                        '',
-                        '    // src/Handler/Collection.php',
-                        '    # a comment',
-                        '    namespace App\\Handler;',
-                    ],
-                ),
+                new RstSample([
+                    $codeBlock,
+                    '',
+                    '    // src/Handler/Collection.php',
+                    '    # a comment',
+                    '    namespace App\\Handler;',
+                ], ),
             ];
         }
 

--- a/tests/Rule/FilenameUsesDashesOnlyTest.php
+++ b/tests/Rule/FilenameUsesDashesOnlyTest.php
@@ -18,9 +18,11 @@ use App\Tests\UnitTestCase;
 use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
+#[AllowMockObjectsWithoutExpectations]
 final class FilenameUsesDashesOnlyTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/FilenameUsesUnderscoresOnlyTest.php
+++ b/tests/Rule/FilenameUsesUnderscoresOnlyTest.php
@@ -18,9 +18,11 @@ use App\Tests\UnitTestCase;
 use App\Value\NullViolation;
 use App\Value\Violation;
 use App\Value\ViolationInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
+#[AllowMockObjectsWithoutExpectations]
 final class FilenameUsesUnderscoresOnlyTest extends UnitTestCase
 {
     #[Test]

--- a/tests/Rule/ForbiddenDirectivesTest.php
+++ b/tests/Rule/ForbiddenDirectivesTest.php
@@ -135,9 +135,7 @@ final class ForbiddenDirectivesTest extends UnitTestCase
     #[Test]
     public function invalidOptionType(): void
     {
-        $this->expectExceptionObject(
-            new InvalidOptionsException('The option "directives" with value ".. caution::" is expected to be of type "array", but is of type "string".'),
-        );
+        $this->expectExceptionObject(new InvalidOptionsException('The option "directives" with value ".. caution::" is expected to be of type "array", but is of type "string".'));
 
         $rule = new ForbiddenDirectives();
         $rule->setOptions([
@@ -148,9 +146,7 @@ final class ForbiddenDirectivesTest extends UnitTestCase
     #[Test]
     public function invalidDirective(): void
     {
-        $this->expectExceptionObject(
-            new InvalidOptionsException('A directive in "directives" is invalid. It needs at least a "directive" key with a string value'),
-        );
+        $this->expectExceptionObject(new InvalidOptionsException('A directive in "directives" is invalid. It needs at least a "directive" key with a string value'));
 
         $rule = new ForbiddenDirectives();
         $rule->setOptions([
@@ -166,9 +162,7 @@ final class ForbiddenDirectivesTest extends UnitTestCase
     #[Test]
     public function missingDirective(): void
     {
-        $this->expectExceptionObject(
-            new InvalidOptionsException('A directive in "directives" is invalid. It needs at least a "directive" key with a string value'),
-        );
+        $this->expectExceptionObject(new InvalidOptionsException('A directive in "directives" is invalid. It needs at least a "directive" key with a string value'));
 
         $rule = new ForbiddenDirectives();
         $rule->setOptions([

--- a/tests/Rule/IndentionTest.php
+++ b/tests/Rule/IndentionTest.php
@@ -227,12 +227,10 @@ RST
         yield 'list item (#) first line' => [
             NullViolation::create(),
             4,
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 #. At the beginning of the request, the Firewall checks the firewall map
    to see if any firewall should be active for this URL;
-RST
-            ),
+RST),
         ];
 
         yield 'list item (#) second line' => [
@@ -248,12 +246,10 @@ RST
         yield 'list item (*) first line' => [
             NullViolation::create(),
             4,
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 * At the beginning of the request, the Firewall checks the firewall map
   to see if any firewall should be active for this URL;
-RST
-            ),
+RST),
         ];
 
         yield 'list item (*) second line' => [
@@ -269,12 +265,10 @@ RST
         yield 'comment (rst) first line' => [
             NullViolation::create(),
             4,
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 .. I am a comment
    and have a second line.
-RST
-            ),
+RST),
         ];
 
         yield 'comment (rst) second line' => [
@@ -290,21 +284,17 @@ RST
         yield 'special char "├─"' => [
             NullViolation::create(),
             4,
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
   ├─ app.php
-RST
-            ),
+RST),
         ];
 
         yield 'special char "└─"' => [
             NullViolation::create(),
             4,
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
   └─ ...
-RST
-            ),
+RST),
         ];
 
         yield 'twig multiline comment' => [
@@ -382,12 +372,10 @@ RST
     {
         yield [
             true,
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 <!-- appends the '@app.username_checker' argument to the parent
      argument list -->
-RST
-            ),
+RST),
         ];
 
         yield [
@@ -401,11 +389,9 @@ RST
 
         yield [
             false,
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 <!-- appends the '@app.username_checker' argument to the parent -->
-RST
-            ),
+RST),
         ];
 
         yield [
@@ -453,12 +439,10 @@ RST
     {
         yield [
             true,
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 {# appends the '@app.username_checker' argument to the parent
    argument list #}
-RST
-            ),
+RST),
         ];
 
         yield [
@@ -472,11 +456,9 @@ RST
 
         yield [
             false,
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 {# appends the '@app.username_checker' argument to the parent #}
-RST
-            ),
+RST),
         ];
 
         yield [false, new RstSample('foo bar')];

--- a/tests/Rule/UnusedLinksTest.php
+++ b/tests/Rule/UnusedLinksTest.php
@@ -44,67 +44,56 @@ final class UnusedLinksTest extends UnitTestCase
 
         yield [
             NullViolation::create(),
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 I am a `Link`_
 
 .. _`Link`: https://example.com
-RST
-            ),
+RST),
         ];
 
         yield [
             NullViolation::create(),
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 I am a `Link`_ and `Link2`_
 
 .. _`Link`: https://example.com
 .. _`Link2`: https://example2.com
-RST
-            ),
+RST),
         ];
 
         yield [
             NullViolation::create(),
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 I am a `Link`_
 
 .. _Link: https://example.com
-RST
-            ),
+RST),
         ];
 
         yield [
             NullViolation::create(),
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 I am a `Link`_ and `Link2`_
 
 .. _Link: https://example.com
 .. _Link2: https://example2.com
-RST
-            ),
+RST),
         ];
 
         yield [
             NullViolation::create(),
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 I am `a Link`_, `some other Link`_ and Link2_
 
 .. _a Link: https://example.com
 .. _Link2: https://example2.com
 .. _`some other Link`: https://example3.com
-RST
-            ),
+RST),
         ];
 
         yield [
             NullViolation::create(),
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 Date Handling
 ~~~~~~~~~~~~~
 
@@ -113,14 +102,12 @@ date or a date-time into a Unix timestamp; for example ``2016-05-27`` or
 ``2016-05-27T02:59:43.1Z`` (`ISO-8601`_)::
 
 .. _`ISO-8601`: http://www.iso.org/iso/iso8601
-RST
-            ),
+RST),
         ];
 
         yield [
             NullViolation::create(),
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 Active Core Members
 ~~~~~~~~~~~~~~~~~~~
 
@@ -198,8 +185,7 @@ Symfony contributions:
 .. _`HeahDude`: https://github.com/HeahDude
 .. _`OskarStark`: https://github.com/OskarStark
 .. _`romainneutron`: https://github.com/romainneutron
-RST
-            ),
+RST),
         ];
     }
 
@@ -212,14 +198,12 @@ RST
                 1,
                 '',
             ),
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 I am a `Link`_
 
 .. _`Link`: https://example.com
 .. _`unused`: https://404.com
-RST
-            ),
+RST),
         ];
 
         yield [
@@ -229,14 +213,12 @@ RST
                 1,
                 '',
             ),
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 I am a `Link`_
 
 .. _Link: https://example.com
 .. _unused: https://404.com
-RST
-            ),
+RST),
         ];
 
         yield [
@@ -246,16 +228,14 @@ RST
                 1,
                 '',
             ),
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 I am a `Link`_
 
 .. _unused2: https://example.com/foo
 .. _Link: https://example.com
 .. _unused1: https://404.com
 .. _`unused 3`: https://example.org
-RST
-            ),
+RST),
         ];
     }
 }

--- a/tests/Rule/ValidUseStatementsTest.php
+++ b/tests/Rule/ValidUseStatementsTest.php
@@ -22,7 +22,7 @@ use App\Value\ViolationInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-final class ValidUseStatementsTests extends UnitTestCase
+final class ValidUseStatementsTest extends UnitTestCase
 {
     #[Test]
     #[DataProvider('checkProvider')]

--- a/tests/Traits/ListTraitTest.php
+++ b/tests/Traits/ListTraitTest.php
@@ -51,11 +51,9 @@ final class ListTraitTest extends UnitTestCase
     {
         yield [
             false,
-            new RstSample(
-                <<<'RST'
+            new RstSample(<<<'RST'
 I am just a cool text!
-RST
-            ),
+RST),
         ];
 
         $list_1 = <<<'RST'


### PR DESCRIPTION
Ran `composer update -W`. Notable version bumps: `friendsofphp/php-cs-fixer` 3.95.21 → 3.95.22, `phpunit/phpunit` 12.5.27 → 12.5.33, `nikic/php-parser` 5.7.0 → 5.8.0, `symfony/*` 7.4.8/7.4.10/7.4.12 → 7.4.17, `sebastian/*` and friends.

Everything else in this PR is fallout from running the toolchain (`make refactoring`, `make cs`, `make docs`) afterwards:

### php-cs-fixer 3.95.22

It now collapses the wrapping of calls whose single argument is a multi-line array or heredoc, which produces a dangling trailing comma:

```php
$content = serialize([
    // ...
],);
```

That is the fixer's own stable output (a second run reports zero changes), but it is ugly enough that holding `friendsofphp/php-cs-fixer` at 3.95.21 for now is a reasonable alternative — happy to split that bump out if preferred.

### rector

* `ContainerBuilderCompileEnvArgumentRector` → `$container->compile(true)`
* `#[AllowMockObjectsWithoutExpectations]` on two rule tests (PHPUnit 12.5)
* `array_all()` / early-return simplifications in `RstParser`
* `final public const` → `public const` in `NoExplicitUseOfCodeBlockPhp`

Two of its changes needed a follow-up so PHPStan stays green:

* Rector removed the `@return static` annotation from `CheckListRule::configure()`, which broke type inference in `Registry` and six rule tests. Changed the return type declaration from `self` to `static` instead, so the annotation is genuinely redundant.
* `tests/Rule/ValidUseStatementsTests.php` had a plural suffix, so PHPUnit never executed it and rector's `ParentTestClassConstructorRector` (which skips classes ending in `Test`) added a `__construct()` overriding the final `TestCase::__construct()`. Renamed to `ValidUseStatementsTest`; the three tests in it pass, and `docs/rules.md` now links the test class.

### rector.php

Removed the five skip entries rector reports as deprecated/never registered, and `StaticDataProviderClassMethodRector` from `withRules()` since it is already part of a registered set.

`make cs`, `make static-code-analysis` and `make docs` are clean.