### PR TITLE
Upgrade to Symfony 8.1

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -34,6 +34,10 @@ $customRules = [
         ],
     ],
     'no_trailing_whitespace_in_string' => false,
+    // Keep in sync with Rector's NewMethodCallWithoutParenthesesRector, which strips these parentheses.
+    'new_expression_parentheses' => [
+        'use_parentheses' => false,
+    ],
 ];
 
 $ruleSet = Php85::create()->withHeader($header)->withRules(Rules::fromArray(array_merge([

--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,14 @@
         "ext-mbstring": "*",
         "composer/semver": "^3.4.4",
         "ondram/ci-detector": "^4.2.0",
-        "symfony/config": "^7.4.4",
-        "symfony/console": "^7.4.4",
-        "symfony/dependency-injection": "^7.4.5",
-        "symfony/finder": "^7.4.5",
-        "symfony/options-resolver": "^7.4.0",
+        "symfony/config": "^8.1.5",
+        "symfony/console": "^8.1.5",
+        "symfony/dependency-injection": "^8.1.5",
+        "symfony/finder": "^8.1.5",
+        "symfony/options-resolver": "^8.1.0",
         "symfony/service-contracts": "^3.6.1",
-        "symfony/string": "^7.4.4",
-        "symfony/yaml": "^7.4.1",
+        "symfony/string": "^8.1.2",
+        "symfony/yaml": "^8.1.5",
         "webmozart/assert": "^2.0"
     },
     "require-dev": {
@@ -33,7 +33,7 @@
         "phpstan/phpstan-webmozart-assert": "^2.0.0",
         "phpunit/phpunit": "^12.5.9",
         "rector/rector": "^2.3.5",
-        "symfony/var-dumper": "^7.4.4"
+        "symfony/var-dumper": "^8.1.5"
     },
     "replace": {
         "paragonie/random_compat": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9aa19f7eeabf6795bc883e8ad564704",
+    "content-hash": "34072ff39ca4d7497fbf906248c3f894",
     "packages": [
         {
             "name": "composer/semver",
@@ -216,34 +216,33 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.17",
+            "version": "v8.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "696e12da8eea497a1a3808d714b43ff67a7df43e"
+                "reference": "ec711a6c14ae287d9618fbd2c9de4e223a1a4b02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/696e12da8eea497a1a3808d714b43ff67a7df43e",
-                "reference": "696e12da8eea497a1a3808d714b43ff67a7df43e",
+                "url": "https://api.github.com/repos/symfony/config/zipball/ec711a6c14ae287d9618fbd2c9de4e223a1a4b02",
+                "reference": "ec711a6c14ae287d9618fbd2c9de4e223a1a4b02",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/filesystem": "^7.1|^8.0",
-                "symfony/polyfill-ctype": "~1.8"
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/finder": "<6.4",
                 "symfony/service-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -271,7 +270,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.17"
+                "source": "https://github.com/symfony/config/tree/v8.1.5"
             },
             "funding": [
                 {
@@ -291,51 +290,53 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-20T09:55:18+00:00"
+            "time": "2026-08-20T09:59:12+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.17",
+            "version": "v8.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "962e18f09ebe68a49039b4c82fc0ea4871824fca"
+                "reference": "d07c06839e33047e2c894a6793248f3fb66c8129"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/962e18f09ebe68a49039b4c82fc0ea4871824fca",
-                "reference": "962e18f09ebe68a49039b4c82fc0ea4871824fca",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d07c06839e33047e2c894a6793248f3fb66c8129",
+                "reference": "d07c06839e33047e2c894a6793248f3fb66c8129",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/polyfill-php85": "^1.32",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2|^8.0"
+                "symfony/string": "^7.4.6|^8.0.6"
             },
             "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
+                "symfony/dependency-injection": "<8.1",
+                "symfony/event-dispatcher": "<8.1"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^8.1",
+                "symfony/event-dispatcher": "^8.1",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -369,7 +370,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.17"
+                "source": "https://github.com/symfony/console/tree/v8.1.5"
             },
             "funding": [
                 {
@@ -389,43 +390,40 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-21T12:09:28+00:00"
+            "time": "2026-08-21T14:29:57+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.17",
+            "version": "v8.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "f318ac9da5aba0be2cf43ecdd562c05a33bc11c0"
+                "reference": "e79d512848b75f92374e473f8e9ead4202c965c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f318ac9da5aba0be2cf43ecdd562c05a33bc11c0",
-                "reference": "f318ac9da5aba0be2cf43ecdd562c05a33bc11c0",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/e79d512848b75f92374e473f8e9ead4202c965c5",
+                "reference": "e79d512848b75f92374e473f8e9ead4202c965c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
                 "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/service-contracts": "^3.6",
-                "symfony/var-exporter": "^6.4.20|^7.2.5|^8.0"
+                "symfony/var-exporter": "^8.1"
             },
             "conflict": {
-                "ext-psr": "<1.1|>=2",
-                "symfony/config": "<6.4",
-                "symfony/finder": "<6.4",
-                "symfony/yaml": "<6.4"
+                "ext-psr": "<1.1|>=2"
             },
             "provide": {
                 "psr/container-implementation": "1.1|2.0",
                 "symfony/service-implementation": "1.1|2.0|3.0"
             },
             "require-dev": {
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -453,7 +451,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.17"
+                "source": "https://github.com/symfony/dependency-injection/tree/v8.1.5"
             },
             "funding": [
                 {
@@ -473,7 +471,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-21T17:40:08+00:00"
+            "time": "2026-08-21T17:47:34+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -619,23 +617,23 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.17",
+            "version": "v8.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "5ce28827081f6d1f0c32eaf3882750f19cb5bbe6"
+                "reference": "8d7acede2b2ae07605783d1c43e49b5767036474"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/5ce28827081f6d1f0c32eaf3882750f19cb5bbe6",
-                "reference": "5ce28827081f6d1f0c32eaf3882750f19cb5bbe6",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8d7acede2b2ae07605783d1c43e49b5767036474",
+                "reference": "8d7acede2b2ae07605783d1c43e49b5767036474",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4.1"
             },
             "require-dev": {
-                "symfony/filesystem": "^6.4|^7.0|^8.0"
+                "symfony/filesystem": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -663,7 +661,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.17"
+                "source": "https://github.com/symfony/finder/tree/v8.1.5"
             },
             "funding": [
                 {
@@ -683,24 +681,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-21T12:09:28+00:00"
+            "time": "2026-08-21T12:16:08+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.4.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
+                "reference": "88f9c561f678a02d54b897014049fa839e33ff82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
-                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/88f9c561f678a02d54b897014049fa839e33ff82",
+                "reference": "88f9c561f678a02d54b897014049fa839e33ff82",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
                 "symfony/deprecation-contracts": "^2.5|^3"
             },
             "type": "library",
@@ -734,7 +732,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
+                "source": "https://github.com/symfony/options-resolver/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -754,7 +752,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/polyfill-deepclone",
@@ -1184,35 +1182,34 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.15",
+            "version": "v8.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "e394af32256bf9e7bf80849d95e589167c10097b"
+                "reference": "286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/e394af32256bf9e7bf80849d95e589167c10097b",
-                "reference": "e394af32256bf9e7bf80849d95e589167c10097b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc",
+                "reference": "286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.33",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1251,7 +1248,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.15"
+                "source": "https://github.com/symfony/string/tree/v8.1.2"
             },
             "funding": [
                 {
@@ -1271,7 +1268,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-28T07:33:02+00:00"
+            "time": "2026-07-28T07:35:25+00:00"
         },
         {
             "name": "symfony/var-exporter",
@@ -1358,28 +1355,28 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.17",
+            "version": "v8.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "0b040d7b66ceb10b7bb24c8e6656257932693a12"
+                "reference": "b3fc9e8888eeb9daddc33bfbd15d282a61f543cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/0b040d7b66ceb10b7bb24c8e6656257932693a12",
-                "reference": "0b040d7b66ceb10b7bb24c8e6656257932693a12",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/b3fc9e8888eeb9daddc33bfbd15d282a61f543cd",
+                "reference": "b3fc9e8888eeb9daddc33bfbd15d282a61f543cd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.4.1",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<6.4"
+                "symfony/console": "<7.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0",
+                "yaml/yaml-test-suite": "*"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -1410,7 +1407,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.17"
+                "source": "https://github.com/symfony/yaml/tree/v8.1.5"
             },
             "funding": [
                 {
@@ -1430,7 +1427,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-21T12:09:28+00:00"
+            "time": "2026-08-21T12:16:08+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1500,83 +1497,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "azjezz/psl",
-            "version": "4.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-standard-library/php-standard-library.git",
-                "reference": "74c95be0214eb7ea39146ed00ac4eb71b45d787b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-standard-library/php-standard-library/zipball/74c95be0214eb7ea39146ed00ac4eb71b45d787b",
-                "reference": "74c95be0214eb7ea39146ed00ac4eb71b45d787b",
-                "shasum": ""
-            },
-            "require": {
-                "ext-bcmath": "*",
-                "ext-intl": "*",
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "ext-sodium": "*",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-                "revolt/event-loop": "^1.0.7"
-            },
-            "require-dev": {
-                "carthage-software/mago": "^1.6.0",
-                "infection/infection": "^0.31.2",
-                "php-coveralls/php-coveralls": "^2.7.0",
-                "phpbench/phpbench": "^1.4.0",
-                "phpunit/phpunit": "^9.6.22"
-            },
-            "suggest": {
-                "php-standard-library/phpstan-extension": "PHPStan integration",
-                "php-standard-library/psalm-plugin": "Psalm integration"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/hhvm/hsl",
-                    "name": "hhvm/hsl"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/bootstrap.php"
-                ],
-                "psr-4": {
-                    "Psl\\": "src/Psl"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "azjezz",
-                    "email": "azjezz@protonmail.com"
-                }
-            ],
-            "description": "PHP Standard Library",
-            "support": {
-                "issues": "https://github.com/php-standard-library/php-standard-library/issues",
-                "source": "https://github.com/php-standard-library/php-standard-library/tree/4.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/azjezz",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/veewee",
-                    "type": "github"
-                }
-            ],
-            "abandoned": "php-standard-library/php-standard-library",
-            "time": "2026-02-24T01:58:53+00:00"
-        },
         {
             "name": "clue/ndjson-react",
             "version": "v1.3.0",
@@ -3197,25 +3117,25 @@
         },
         {
             "name": "maglnet/composer-require-checker",
-            "version": "4.20.0",
+            "version": "4.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maglnet/ComposerRequireChecker.git",
-                "reference": "c62d517ef5ac2d347dd9b3d02c1cc16c0f1091e2"
+                "reference": "a15ec28d7a747109682c7774af665d2540516750"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maglnet/ComposerRequireChecker/zipball/c62d517ef5ac2d347dd9b3d02c1cc16c0f1091e2",
-                "reference": "c62d517ef5ac2d347dd9b3d02c1cc16c0f1091e2",
+                "url": "https://api.github.com/repos/maglnet/ComposerRequireChecker/zipball/a15ec28d7a747109682c7774af665d2540516750",
+                "reference": "a15ec28d7a747109682c7774af665d2540516750",
                 "shasum": ""
             },
             "require": {
-                "azjezz/psl": "^4.2.0",
                 "composer-runtime-api": "^2.0.0",
                 "ext-phar": "*",
                 "nikic/php-parser": "^5.7.0",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-                "symfony/console": "^7.4.1",
+                "php": "~8.4.0 || ~8.5.0",
+                "php-standard-library/php-standard-library": "^6.1.1",
+                "symfony/console": "^8.0.7",
                 "webmozart/glob": "^4.7.0"
             },
             "conflict": {
@@ -3224,15 +3144,15 @@
             "require-dev": {
                 "doctrine/coding-standard": "^14.0.0",
                 "ext-zend-opcache": "*",
-                "phing/phing": "^3.1.1",
-                "php-standard-library/phpstan-extension": "^2.0.2",
+                "phing/phing": "^3.1.2",
+                "php-standard-library/phpstan-extension": "^2.0.3",
                 "php-standard-library/psalm-plugin": "^2.3",
-                "phpstan/phpstan": "^2.1.33",
-                "phpunit/phpunit": "^12.5.4",
+                "phpstan/phpstan": "^2.1.40",
+                "phpunit/phpunit": "^12.5.14",
                 "psalm/plugin-phpunit": "^0.19.5",
-                "roave/infection-static-analysis-plugin": "^1.42.0",
-                "spatie/temporary-directory": "^2.3.0",
-                "vimeo/psalm": "^6.14.3"
+                "roave/infection-static-analysis-plugin": "^1.43.0",
+                "spatie/temporary-directory": "^2.3.1",
+                "vimeo/psalm": "^6.16.1"
             },
             "bin": [
                 "bin/composer-require-checker"
@@ -3277,9 +3197,9 @@
             ],
             "support": {
                 "issues": "https://github.com/maglnet/ComposerRequireChecker/issues",
-                "source": "https://github.com/maglnet/ComposerRequireChecker/tree/4.20.0"
+                "source": "https://github.com/maglnet/ComposerRequireChecker/tree/4.24.0"
             },
-            "time": "2025-12-29T11:34:42+00:00"
+            "time": "2026-03-20T12:51:42+00:00"
         },
         {
             "name": "marc-mabe/php-enum",
@@ -3640,6 +3560,296 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-standard-library/php-standard-library",
+            "version": "6.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-standard-library/php-standard-library.git",
+                "reference": "331f3ab363508825e62c42725f96c091bcceb970"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-standard-library/php-standard-library/zipball/331f3ab363508825e62c42725f96c091bcceb970",
+                "reference": "331f3ab363508825e62c42725f96c091bcceb970",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "ext-sodium": "*",
+                "php": "~8.4.0 || ~8.5.0",
+                "revolt/event-loop": "^1.0.8"
+            },
+            "conflict": {
+                "azjezz/psl": "*"
+            },
+            "replace": {
+                "php-standard-library/ansi": "self.version",
+                "php-standard-library/async": "self.version",
+                "php-standard-library/binary": "self.version",
+                "php-standard-library/cache": "self.version",
+                "php-standard-library/channel": "self.version",
+                "php-standard-library/cidr": "self.version",
+                "php-standard-library/class": "self.version",
+                "php-standard-library/collection": "self.version",
+                "php-standard-library/comparison": "self.version",
+                "php-standard-library/compression": "self.version",
+                "php-standard-library/crypto": "self.version",
+                "php-standard-library/data-structure": "self.version",
+                "php-standard-library/date-time": "self.version",
+                "php-standard-library/default": "self.version",
+                "php-standard-library/dict": "self.version",
+                "php-standard-library/dns": "self.version",
+                "php-standard-library/dnssec": "self.version",
+                "php-standard-library/either": "self.version",
+                "php-standard-library/either-or-both": "self.version",
+                "php-standard-library/encoding": "self.version",
+                "php-standard-library/env": "self.version",
+                "php-standard-library/file": "self.version",
+                "php-standard-library/filesystem": "self.version",
+                "php-standard-library/foundation": "self.version",
+                "php-standard-library/fun": "self.version",
+                "php-standard-library/graph": "self.version",
+                "php-standard-library/h2": "self.version",
+                "php-standard-library/hash": "self.version",
+                "php-standard-library/hpack": "self.version",
+                "php-standard-library/html": "self.version",
+                "php-standard-library/http-client": "self.version",
+                "php-standard-library/http-message": "self.version",
+                "php-standard-library/interface": "self.version",
+                "php-standard-library/interoperability": "self.version",
+                "php-standard-library/io": "self.version",
+                "php-standard-library/ip": "self.version",
+                "php-standard-library/iri": "self.version",
+                "php-standard-library/iter": "self.version",
+                "php-standard-library/json": "self.version",
+                "php-standard-library/locale": "self.version",
+                "php-standard-library/math": "self.version",
+                "php-standard-library/message": "self.version",
+                "php-standard-library/mime": "self.version",
+                "php-standard-library/network": "self.version",
+                "php-standard-library/observer": "self.version",
+                "php-standard-library/option": "self.version",
+                "php-standard-library/os": "self.version",
+                "php-standard-library/password": "self.version",
+                "php-standard-library/process": "self.version",
+                "php-standard-library/promise": "self.version",
+                "php-standard-library/pseudo-random": "self.version",
+                "php-standard-library/punycode": "self.version",
+                "php-standard-library/random-sequence": "self.version",
+                "php-standard-library/range": "self.version",
+                "php-standard-library/regex": "self.version",
+                "php-standard-library/result": "self.version",
+                "php-standard-library/runtime": "self.version",
+                "php-standard-library/secure-random": "self.version",
+                "php-standard-library/shell": "self.version",
+                "php-standard-library/smtp": "self.version",
+                "php-standard-library/socks": "self.version",
+                "php-standard-library/str": "self.version",
+                "php-standard-library/tcp": "self.version",
+                "php-standard-library/terminal": "self.version",
+                "php-standard-library/tls": "self.version",
+                "php-standard-library/trait": "self.version",
+                "php-standard-library/tree": "self.version",
+                "php-standard-library/type": "self.version",
+                "php-standard-library/udp": "self.version",
+                "php-standard-library/unix": "self.version",
+                "php-standard-library/uri": "self.version",
+                "php-standard-library/url": "self.version",
+                "php-standard-library/vec": "self.version"
+            },
+            "require-dev": {
+                "carthage-software/mago": "^1.29.0",
+                "ext-brotli": "*",
+                "infection/infection": "^0.32.6",
+                "php-coveralls/php-coveralls": "^2.9.1",
+                "phpbench/phpbench": "^1.6.0",
+                "phpunit/phpunit": "^13.0.5"
+            },
+            "suggest": {
+                "php-standard-library/phpstan-extension": "PHPStan integration",
+                "php-standard-library/psalm-plugin": "Psalm integration"
+            },
+            "bin": [
+                "bin/psl"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-next": "6.2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "packages/foundation/src/Psl/bootstrap.php",
+                    "packages/ansi/src/Psl/bootstrap.php",
+                    "packages/async/src/Psl/bootstrap.php",
+                    "packages/binary/src/Psl/bootstrap.php",
+                    "packages/cache/src/Psl/bootstrap.php",
+                    "packages/channel/src/Psl/bootstrap.php",
+                    "packages/class/src/Psl/bootstrap.php",
+                    "packages/comparison/src/Psl/bootstrap.php",
+                    "packages/compression/src/Psl/bootstrap.php",
+                    "packages/crypto/src/Psl/bootstrap.php",
+                    "packages/date-time/src/Psl/bootstrap.php",
+                    "packages/dict/src/Psl/bootstrap.php",
+                    "packages/encoding/src/Psl/bootstrap.php",
+                    "packages/env/src/Psl/bootstrap.php",
+                    "packages/dns/src/Psl/bootstrap.php",
+                    "packages/dnssec/src/Psl/bootstrap.php",
+                    "packages/either-or-both/src/Psl/bootstrap.php",
+                    "packages/file/src/Psl/bootstrap.php",
+                    "packages/filesystem/src/Psl/bootstrap.php",
+                    "packages/fun/src/Psl/bootstrap.php",
+                    "packages/graph/src/Psl/bootstrap.php",
+                    "packages/h2/src/Psl/bootstrap.php",
+                    "packages/hash/src/Psl/bootstrap.php",
+                    "packages/hpack/src/Psl/bootstrap.php",
+                    "packages/html/src/Psl/bootstrap.php",
+                    "packages/http-client/src/Psl/bootstrap.php",
+                    "packages/http-message/src/Psl/bootstrap.php",
+                    "packages/interface/src/Psl/bootstrap.php",
+                    "packages/io/src/Psl/bootstrap.php",
+                    "packages/iter/src/Psl/bootstrap.php",
+                    "packages/json/src/Psl/bootstrap.php",
+                    "packages/mime/src/Psl/bootstrap.php",
+                    "packages/message/src/Psl/bootstrap.php",
+                    "packages/math/src/Psl/bootstrap.php",
+                    "packages/network/src/Psl/bootstrap.php",
+                    "packages/option/src/Psl/bootstrap.php",
+                    "packages/os/src/Psl/bootstrap.php",
+                    "packages/password/src/Psl/bootstrap.php",
+                    "packages/pseudo-random/src/Psl/bootstrap.php",
+                    "packages/punycode/src/Psl/bootstrap.php",
+                    "packages/range/src/Psl/bootstrap.php",
+                    "packages/regex/src/Psl/bootstrap.php",
+                    "packages/result/src/Psl/bootstrap.php",
+                    "packages/runtime/src/Psl/bootstrap.php",
+                    "packages/secure-random/src/Psl/bootstrap.php",
+                    "packages/smtp/src/Psl/bootstrap.php",
+                    "packages/shell/src/Psl/bootstrap.php",
+                    "packages/socks/src/Psl/bootstrap.php",
+                    "packages/str/src/Psl/bootstrap.php",
+                    "packages/tcp/src/Psl/bootstrap.php",
+                    "packages/terminal/src/Psl/bootstrap.php",
+                    "packages/tls/src/Psl/bootstrap.php",
+                    "packages/trait/src/Psl/bootstrap.php",
+                    "packages/tree/src/Psl/bootstrap.php",
+                    "packages/type/src/Psl/bootstrap.php",
+                    "packages/udp/src/Psl/bootstrap.php",
+                    "packages/unix/src/Psl/bootstrap.php",
+                    "packages/uri/src/Psl/bootstrap.php",
+                    "packages/url/src/Psl/bootstrap.php",
+                    "packages/iri/src/Psl/bootstrap.php",
+                    "packages/vec/src/Psl/bootstrap.php"
+                ],
+                "psr-4": {
+                    "Psl\\": "packages/foundation/src/Psl/",
+                    "Psl\\H2\\": "packages/h2/src/Psl/H2/",
+                    "Psl\\IO\\": "packages/io/src/Psl/IO/",
+                    "Psl\\IP\\": "packages/ip/src/Psl/IP/",
+                    "Psl\\OS\\": "packages/os/src/Psl/OS/",
+                    "Psl\\DNS\\": "packages/dns/src/Psl/DNS/",
+                    "Psl\\Env\\": "packages/env/src/Psl/Env/",
+                    "Psl\\Fun\\": "packages/fun/src/Psl/Fun/",
+                    "Psl\\IRI\\": "packages/iri/src/Psl/IRI/",
+                    "Psl\\Str\\": "packages/str/src/Psl/Str/",
+                    "Psl\\TCP\\": "packages/tcp/src/Psl/TCP/",
+                    "Psl\\TLS\\": "packages/tls/src/Psl/TLS/",
+                    "Psl\\UDP\\": "packages/udp/src/Psl/UDP/",
+                    "Psl\\URI\\": "packages/uri/src/Psl/URI/",
+                    "Psl\\URL\\": "packages/url/src/Psl/URL/",
+                    "Psl\\Vec\\": "packages/vec/src/Psl/Vec/",
+                    "Psl\\Ansi\\": "packages/ansi/src/Psl/Ansi/",
+                    "Psl\\CIDR\\": "packages/cidr/src/Psl/CIDR/",
+                    "Psl\\Dict\\": "packages/dict/src/Psl/Dict/",
+                    "Psl\\File\\": "packages/file/src/Psl/File/",
+                    "Psl\\Hash\\": "packages/hash/src/Psl/Hash/",
+                    "Psl\\Html\\": "packages/html/src/Psl/Html/",
+                    "Psl\\Iter\\": "packages/iter/src/Psl/Iter/",
+                    "Psl\\Json\\": "packages/json/src/Psl/Json/",
+                    "Psl\\MIME\\": "packages/mime/src/Psl/MIME/",
+                    "Psl\\Math\\": "packages/math/src/Psl/Math/",
+                    "Psl\\SMTP\\": "packages/smtp/src/Psl/SMTP/",
+                    "Psl\\Tree\\": "packages/tree/src/Psl/Tree/",
+                    "Psl\\Type\\": "packages/type/src/Psl/Type/",
+                    "Psl\\Unix\\": "packages/unix/src/Psl/Unix/",
+                    "Psl\\Async\\": "packages/async/src/Psl/Async/",
+                    "Psl\\Cache\\": "packages/cache/src/Psl/Cache/",
+                    "Psl\\Class\\": "packages/class/src/Psl/Class/",
+                    "Psl\\Graph\\": "packages/graph/src/Psl/Graph/",
+                    "Psl\\HPACK\\": "packages/hpack/src/Psl/HPACK/",
+                    "Psl\\Range\\": "packages/range/src/Psl/Range/",
+                    "Psl\\Regex\\": "packages/regex/src/Psl/Regex/",
+                    "Psl\\Shell\\": "packages/shell/src/Psl/Shell/",
+                    "Psl\\Socks\\": "packages/socks/src/Psl/Socks/",
+                    "Psl\\Trait\\": "packages/trait/src/Psl/Trait/",
+                    "Psl\\Binary\\": "packages/binary/src/Psl/Binary/",
+                    "Psl\\Crypto\\": "packages/crypto/src/Psl/Crypto/",
+                    "Psl\\DNSSEC\\": "packages/dnssec/src/Psl/DNSSEC/",
+                    "Psl\\Either\\": "packages/either/src/Psl/Either/",
+                    "Psl\\Locale\\": "packages/locale/src/Psl/Locale/",
+                    "Psl\\Option\\": "packages/option/src/Psl/Option/",
+                    "Psl\\Result\\": "packages/result/src/Psl/Result/",
+                    "Psl\\Channel\\": "packages/channel/src/Psl/Channel/",
+                    "Psl\\Default\\": "packages/default/src/Psl/Default/",
+                    "Psl\\Message\\": "packages/message/src/Psl/Message/",
+                    "Psl\\Network\\": "packages/network/src/Psl/Network/",
+                    "Psl\\Process\\": "packages/process/src/Psl/Process/",
+                    "Psl\\Promise\\": "packages/promise/src/Psl/Promise/",
+                    "Psl\\Runtime\\": "packages/runtime/src/Psl/Runtime/",
+                    "Psl\\DateTime\\": "packages/date-time/src/Psl/DateTime/",
+                    "Psl\\Encoding\\": "packages/encoding/src/Psl/Encoding/",
+                    "Psl\\Observer\\": "packages/observer/src/Psl/Observer/",
+                    "Psl\\Password\\": "packages/password/src/Psl/Password/",
+                    "Psl\\Punycode\\": "packages/punycode/src/Psl/Punycode/",
+                    "Psl\\Terminal\\": "packages/terminal/src/Psl/Terminal/",
+                    "Psl\\Interface\\": "packages/interface/src/Psl/Interface/",
+                    "Psl\\Collection\\": "packages/collection/src/Psl/Collection/",
+                    "Psl\\Comparison\\": "packages/comparison/src/Psl/Comparison/",
+                    "Psl\\Filesystem\\": "packages/filesystem/src/Psl/Filesystem/",
+                    "Psl\\Compression\\": "packages/compression/src/Psl/Compression/",
+                    "Psl\\HTTP\\Client\\": "packages/http-client/src/Psl/HTTP/Client/",
+                    "Psl\\EitherOrBoth\\": "packages/either-or-both/src/Psl/EitherOrBoth/",
+                    "Psl\\HTTP\\Message\\": "packages/http-message/src/Psl/HTTP/Message/",
+                    "Psl\\PseudoRandom\\": "packages/pseudo-random/src/Psl/PseudoRandom/",
+                    "Psl\\SecureRandom\\": "packages/secure-random/src/Psl/SecureRandom/",
+                    "Psl\\DataStructure\\": "packages/data-structure/src/Psl/DataStructure/",
+                    "Psl\\RandomSequence\\": "packages/random-sequence/src/Psl/RandomSequence/",
+                    "Psl\\Interoperability\\": "packages/interoperability/src/Psl/Interoperability/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "azjezz",
+                    "email": "azjezz@protonmail.com"
+                }
+            ],
+            "description": "PHP Standard Library",
+            "support": {
+                "issues": "https://github.com/php-standard-library/php-standard-library/issues",
+                "source": "https://github.com/php-standard-library/php-standard-library/tree/6.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/azjezz",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/veewee",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-23T22:30:15+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -6722,31 +6932,31 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.17",
+            "version": "v8.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "53712df8727da1744490202eeb9cb50d4b95419d"
+                "reference": "61743d9bc7ab23b194527ca1be2fafd7dc93b74a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/53712df8727da1744490202eeb9cb50d4b95419d",
-                "reference": "53712df8727da1744490202eeb9cb50d4b95419d",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/61743d9bc7ab23b194527ca1be2fafd7dc93b74a",
+                "reference": "61743d9bc7ab23b194527ca1be2fafd7dc93b74a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4.1",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
-                "symfony/console": "<6.4"
+                "symfony/console": "<7.4",
+                "symfony/error-handler": "<7.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
                 "twig/twig": "^3.12|^4.0"
             },
             "bin": [
@@ -6785,7 +6995,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.17"
+                "source": "https://github.com/symfony/var-dumper/tree/v8.1.5"
             },
             "funding": [
                 {
@@ -6805,7 +7015,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-21T12:09:28+00:00"
+            "time": "2026-08-21T12:16:08+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/rector.php
+++ b/rector.php
@@ -14,13 +14,10 @@ declare(strict_types=1);
 use Rector\CodeQuality\Rector\Attribute\SortAttributeNamedArgsRector;
 use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector;
 use Rector\CodeQuality\Rector\FuncCall\SortCallLikeNamedArgsRector;
-use Rector\CodeQuality\Rector\If_\CombineIfRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
-use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
-use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
 
@@ -61,11 +58,8 @@ return RectorConfig::configure()
         RemoveNullArgOnNullDefaultParamRector::class => [
             __DIR__.'/tests', // Keep explicit null arguments in tests for clarity
         ],
-        AddOverrideAttributeToOverriddenMethodsRector::class,
         LocallyCalledStaticMethodToNonStaticRector::class,
         PreferPHPUnitThisCallRector::class,
-        NullToStrictStringFuncCallArgRector::class, // Avoid redundant casts when value is already a string
-        CombineIfRector::class, // Keep nested ifs for better readability
         RecastingRemovalRector::class, // Keep explicit casts for clarity
     ])
     ->withRules([

--- a/src/Analyzer/FileCache.php
+++ b/src/Analyzer/FileCache.php
@@ -124,7 +124,7 @@ final class FileCache implements Cache
             serialize([
                 'version' => Application::VERSION,
                 'payload' => $cache,
-            ],),
+            ], ),
         );
     }
 

--- a/src/Command/RulesCommand.php
+++ b/src/Command/RulesCommand.php
@@ -131,12 +131,6 @@ class RulesCommand extends Command
                         $required = false;
 
                         $default = $introspector->getDefault($option);
-
-                        // Since Symfony 8.0, the introspector returns the raw closure of a
-                        // nested options definition instead of the resolved array.
-                        if ($default instanceof \Closure) {
-                            $default = [];
-                        }
                     }
                 }
 

--- a/src/Command/RulesCommand.php
+++ b/src/Command/RulesCommand.php
@@ -131,6 +131,12 @@ class RulesCommand extends Command
                         $required = false;
 
                         $default = $introspector->getDefault($option);
+
+                        // Since Symfony 8.0, the introspector returns the raw closure of a
+                        // nested options definition instead of the resolved array.
+                        if ($default instanceof \Closure) {
+                            $default = [];
+                        }
                     }
                 }
 
@@ -254,7 +260,7 @@ class RulesCommand extends Command
         $this->io->writeln(\sprintf(
             '- Rule class: %s',
             $ruleLink,
-        ),);
+        ), );
 
         $testName = \sprintf(
             'App\Tests\Rule\\%sTest',
@@ -270,7 +276,7 @@ class RulesCommand extends Command
             $this->io->writeln(\sprintf(
                 '- Test class: %s',
                 $testLink,
-            ),);
+            ), );
         }
 
         $this->io->newLine();

--- a/src/Rule/ArgumentVariableMustMatchType.php
+++ b/src/Rule/ArgumentVariableMustMatchType.php
@@ -36,7 +36,7 @@ final class ArgumentVariableMustMatchType extends AbstractRule implements Config
         $resolver
             ->setRequired('arguments')
             ->setAllowedTypes('arguments', 'array')
-            ->setDefault('arguments', static function (OptionsResolver $connResolver): void {
+            ->setOptions('arguments', static function (OptionsResolver $connResolver): void {
                 $connResolver
                     ->setPrototype(true)
                     ->setRequired(['type', 'name']);

--- a/src/Rule/Indention.php
+++ b/src/Rule/Indention.php
@@ -100,7 +100,7 @@ final class Indention extends AbstractRule implements Configurable, LineContentR
                 || PhpHelper::isFirstLineOfMultilineComment($line)
             ) {
                 $minus = 0;
-            } elseif ((new PhpHelper())->isPartOfMultilineComment($lines, $number)) {
+            } elseif (new PhpHelper()->isPartOfMultilineComment($lines, $number)) {
                 $customMessage = 'Please fix the indention of the multiline comment.';
 
                 if (PhpHelper::isLastLineOfMultilineComment($line)
@@ -111,11 +111,11 @@ final class Indention extends AbstractRule implements Configurable, LineContentR
                     $minus = 1;
                 }
             } elseif (PhpHelper::isLastLineOfDocBlock($line)
-                && (new PhpHelper())->isPartOfDocBlock($lines, $number)
+                && new PhpHelper()->isPartOfDocBlock($lines, $number)
             ) {
                 $customMessage = 'Please fix the indention of the PHP DocBlock.';
                 $minus = 1;
-            } elseif ((new PhpHelper())->isPartOfDocBlock($lines, $number)) {
+            } elseif (new PhpHelper()->isPartOfDocBlock($lines, $number)) {
                 $customMessage = 'Please fix the indention of the PHP DocBlock.';
                 $minus = 1;
             }

--- a/src/Traits/ListTrait.php
+++ b/src/Traits/ListTrait.php
@@ -24,7 +24,7 @@ trait ListTrait
         $lines->seek($number);
 
         if (RstParser::isListItem($lines->current())) {
-            return !(new PhpHelper())->isPartOfMultilineComment($lines, $number) && !(new PhpHelper())->isPartOfDocBlock($lines, $number);
+            return !new PhpHelper()->isPartOfMultilineComment($lines, $number) && !new PhpHelper()->isPartOfDocBlock($lines, $number);
         }
 
         $currentIndention = $lines->current()->indention();

--- a/tests/Analyzer/FileCacheTest.php
+++ b/tests/Analyzer/FileCacheTest.php
@@ -61,7 +61,7 @@ final class FileCacheTest extends UnitTestCase
                     'violations' => [],
                 ],
             ],
-        ],);
+        ], );
         $cacheFile = vfsStream::newFile('.doctor-rst.cache')
             ->withContent($content)
             ->at($this->root);
@@ -104,7 +104,7 @@ final class FileCacheTest extends UnitTestCase
                     'violations' => [],
                 ],
             ],
-        ],);
+        ], );
         $cacheFile = vfsStream::newFile('.doctor-rst.cache')
             ->withContent($content)
             ->at($this->root);
@@ -131,7 +131,7 @@ final class FileCacheTest extends UnitTestCase
                     'violations' => [],
                 ],
             ],
-        ],);
+        ], );
         $cacheFile = vfsStream::newFile('.doctor-rst.cache')
             ->withContent($content)
             ->at($this->root);
@@ -153,7 +153,7 @@ final class FileCacheTest extends UnitTestCase
                     'violations' => [],
                 ],
             ],
-        ],);
+        ], );
         $cacheFile = vfsStream::newFile('.doctor-rst.cache')
             ->withContent($content)
             ->at($this->root);

--- a/tests/Analyzer/RstAnalyzerTest.php
+++ b/tests/Analyzer/RstAnalyzerTest.php
@@ -26,7 +26,7 @@ final class RstAnalyzerTest extends UnitTestCase
         $maxBlankLines = new MaxBlankLines();
         $maxBlankLines->setOptions(['max' => 3]);
 
-        $violations = (new RstAnalyzer())->analyze(
+        $violations = new RstAnalyzer()->analyze(
             new \SplFileInfo(__DIR__.'/../Fixtures/max_blanklines.rst'),
             [$maxBlankLines],
         );

--- a/tests/Formatter/ConsoleFormatterTest.php
+++ b/tests/Formatter/ConsoleFormatterTest.php
@@ -52,7 +52,7 @@ final class ConsoleFormatterTest extends UnitTestCase
             ],
         ]);
 
-        (new ConsoleFormatter())->format($style, $analyzerResult, $analyzeDir, true);
+        new ConsoleFormatter()->format($style, $analyzerResult, $analyzeDir, true);
 
         $expected = <<<'OUTPUT'
 docs/index.rst ✘

--- a/tests/Formatter/GithubFormatterTest.php
+++ b/tests/Formatter/GithubFormatterTest.php
@@ -53,7 +53,7 @@ final class GithubFormatterTest extends UnitTestCase
             ],
         ]);
 
-        (new GithubFormatter(new ConsoleFormatter()))->format($style, $analyzerResult, $analyzeDir, false);
+        new GithubFormatter(new ConsoleFormatter())->format($style, $analyzerResult, $analyzeDir, false);
 
         $expected = <<<OUTPUT
 docs/index.rst ✘

--- a/tests/Formatter/RegistryTest.php
+++ b/tests/Formatter/RegistryTest.php
@@ -27,7 +27,7 @@ final class RegistryTest extends UnitTestCase
         $this->expectException(FormatterNotFound::class);
         $this->expectExceptionMessage('Formatter "invalid" not found');
 
-        (new Registry(new ConsoleFormatter()))->get('invalid');
+        new Registry(new ConsoleFormatter())->get('invalid');
     }
 
     #[Test]
@@ -35,6 +35,6 @@ final class RegistryTest extends UnitTestCase
     {
         $formatter = new ConsoleFormatter();
 
-        self::assertSame($formatter, (new Registry($formatter))->get('console'));
+        self::assertSame($formatter, new Registry($formatter)->get('console'));
     }
 }

--- a/tests/Helper/PhpHelperTest.php
+++ b/tests/Helper/PhpHelperTest.php
@@ -118,7 +118,7 @@ final class PhpHelperTest extends UnitTestCase
     {
         self::assertSame(
             $expected,
-            (new PhpHelper())->isPartOfDocBlock($sample->lines, $sample->lineNumber),
+            new PhpHelper()->isPartOfDocBlock($sample->lines, $sample->lineNumber),
         );
     }
 
@@ -149,7 +149,7 @@ RST;
     {
         self::assertSame(
             $expected,
-            (new PhpHelper())->isPartOfMultilineComment($sample->lines, $sample->lineNumber),
+            new PhpHelper()->isPartOfMultilineComment($sample->lines, $sample->lineNumber),
         );
     }
 

--- a/tests/Rst/Value/LineTest.php
+++ b/tests/Rst/Value/LineTest.php
@@ -32,7 +32,7 @@ final class LineTest extends UnitTestCase
     #[DataProvider('cleanProvider')]
     public function clean(string $expected, string $string): void
     {
-        self::assertSame($expected, (new Line($string))->clean()->toString());
+        self::assertSame($expected, new Line($string)->clean()->toString());
     }
 
     /**
@@ -78,7 +78,7 @@ final class LineTest extends UnitTestCase
     #[DataProvider('isBlankProvider')]
     public function isBlank(bool $expected, string $string): void
     {
-        self::assertSame($expected, (new Line($string))->isBlank());
+        self::assertSame($expected, new Line($string)->isBlank());
     }
 
     /**
@@ -96,7 +96,7 @@ final class LineTest extends UnitTestCase
     #[DataProvider('indentionProvider')]
     public function indention(int $expected, string $string): void
     {
-        self::assertSame($expected, (new Line($string))->indention());
+        self::assertSame($expected, new Line($string)->indention());
     }
 
     /**
@@ -113,7 +113,7 @@ final class LineTest extends UnitTestCase
     #[DataProvider('isHeadlineProvider')]
     public function isHeadline(bool $expected, string $string): void
     {
-        self::assertSame($expected, (new Line($string))->isHeadline());
+        self::assertSame($expected, new Line($string)->isHeadline());
     }
 
     /**
@@ -137,7 +137,7 @@ final class LineTest extends UnitTestCase
     #[DataProvider('isDirectiveProvider')]
     public function isDirective(bool $expected, string $string): void
     {
-        self::assertSame($expected, (new Line($string))->isDirective());
+        self::assertSame($expected, new Line($string)->isDirective());
     }
 
     /**
@@ -163,7 +163,7 @@ final class LineTest extends UnitTestCase
     #[DataProvider('isDefaultDirectiveProvider')]
     public function isDefaultDirective(bool $expected, string $string): void
     {
-        self::assertSame($expected, (new Line($string))->isDefaultDirective());
+        self::assertSame($expected, new Line($string)->isDefaultDirective());
     }
 
     /**

--- a/tests/Rule/AmericanEnglishTest.php
+++ b/tests/Rule/AmericanEnglishTest.php
@@ -31,7 +31,7 @@ final class AmericanEnglishTest extends UnitTestCase
         $configuredRules = [];
 
         foreach (AmericanEnglish::getList() as $search => $message) {
-            $configuredRules[] = (new AmericanEnglish())->configure($search, $message);
+            $configuredRules[] = new AmericanEnglish()->configure($search, $message);
         }
 
         $violations = [];

--- a/tests/Rule/BlankLineAfterAnchorTest.php
+++ b/tests/Rule/BlankLineAfterAnchorTest.php
@@ -30,7 +30,7 @@ final class BlankLineAfterAnchorTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new BlankLineAfterAnchor())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new BlankLineAfterAnchor()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/BlankLineAfterColonTest.php
+++ b/tests/Rule/BlankLineAfterColonTest.php
@@ -30,7 +30,7 @@ final class BlankLineAfterColonTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new BlankLineAfterColon())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new BlankLineAfterColon()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/BlankLineAfterDirectiveTest.php
+++ b/tests/Rule/BlankLineAfterDirectiveTest.php
@@ -31,7 +31,7 @@ final class BlankLineAfterDirectiveTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new BlankLineAfterDirective())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new BlankLineAfterDirective()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/BlankLineAfterFilepathInCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInCodeBlockTest.php
@@ -35,7 +35,7 @@ final class BlankLineAfterFilepathInCodeBlockTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new BlankLineAfterFilepathInCodeBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new BlankLineAfterFilepathInCodeBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/BlankLineAfterFilepathInPhpCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInPhpCodeBlockTest.php
@@ -30,7 +30,7 @@ final class BlankLineAfterFilepathInPhpCodeBlockTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new BlankLineAfterFilepathInPhpCodeBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new BlankLineAfterFilepathInPhpCodeBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/BlankLineAfterFilepathInTwigCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInTwigCodeBlockTest.php
@@ -30,7 +30,7 @@ final class BlankLineAfterFilepathInTwigCodeBlockTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new BlankLineAfterFilepathInTwigCodeBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new BlankLineAfterFilepathInTwigCodeBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/BlankLineAfterFilepathInXmlCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInXmlCodeBlockTest.php
@@ -30,7 +30,7 @@ final class BlankLineAfterFilepathInXmlCodeBlockTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new BlankLineAfterFilepathInXmlCodeBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new BlankLineAfterFilepathInXmlCodeBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/BlankLineAfterFilepathInYamlCodeBlockTest.php
+++ b/tests/Rule/BlankLineAfterFilepathInYamlCodeBlockTest.php
@@ -30,7 +30,7 @@ final class BlankLineAfterFilepathInYamlCodeBlockTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new BlankLineAfterFilepathInYamlCodeBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new BlankLineAfterFilepathInYamlCodeBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/BlankLineBeforeDirectiveTest.php
+++ b/tests/Rule/BlankLineBeforeDirectiveTest.php
@@ -31,7 +31,7 @@ final class BlankLineBeforeDirectiveTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new BlankLineBeforeDirective())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new BlankLineBeforeDirective()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/ComposerDevOptionAtTheEndTest.php
+++ b/tests/Rule/ComposerDevOptionAtTheEndTest.php
@@ -30,7 +30,7 @@ final class ComposerDevOptionAtTheEndTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new ComposerDevOptionAtTheEnd())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new ComposerDevOptionAtTheEnd()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/ComposerDevOptionNotAtTheEndTest.php
+++ b/tests/Rule/ComposerDevOptionNotAtTheEndTest.php
@@ -30,7 +30,7 @@ final class ComposerDevOptionNotAtTheEndTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new ComposerDevOptionNotAtTheEnd())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new ComposerDevOptionNotAtTheEnd()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/DeprecatedDirectiveShouldHaveVersionTest.php
+++ b/tests/Rule/DeprecatedDirectiveShouldHaveVersionTest.php
@@ -31,7 +31,7 @@ final class DeprecatedDirectiveShouldHaveVersionTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new DeprecatedDirectiveShouldHaveVersion(new VersionParser()))
+            new DeprecatedDirectiveShouldHaveVersion(new VersionParser())
                 ->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }

--- a/tests/Rule/EnsureAttributeBetweenBackticksInContentTest.php
+++ b/tests/Rule/EnsureAttributeBetweenBackticksInContentTest.php
@@ -30,7 +30,7 @@ final class EnsureAttributeBetweenBackticksInContentTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new EnsureAttributeBetweenBackticksInContent())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new EnsureAttributeBetweenBackticksInContent()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/EnsureBashPromptBeforeComposerCommandTest.php
+++ b/tests/Rule/EnsureBashPromptBeforeComposerCommandTest.php
@@ -31,7 +31,7 @@ final class EnsureBashPromptBeforeComposerCommandTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new EnsureBashPromptBeforeComposerCommand())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new EnsureBashPromptBeforeComposerCommand()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/EnsureClassConstantTest.php
+++ b/tests/Rule/EnsureClassConstantTest.php
@@ -30,7 +30,7 @@ final class EnsureClassConstantTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new EnsureClassConstant())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new EnsureClassConstant()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/EnsureExactlyOneSpaceBeforeDirectiveTypeTest.php
+++ b/tests/Rule/EnsureExactlyOneSpaceBeforeDirectiveTypeTest.php
@@ -31,7 +31,7 @@ final class EnsureExactlyOneSpaceBeforeDirectiveTypeTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new EnsureExactlyOneSpaceBeforeDirectiveType())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new EnsureExactlyOneSpaceBeforeDirectiveType()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest.php
+++ b/tests/Rule/EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest.php
@@ -31,7 +31,7 @@ final class EnsureExactlyOneSpaceBetweenLinkDefinitionAndLinkTest extends UnitTe
     {
         self::assertEquals(
             $expected,
-            (new EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new EnsureExactlyOneSpaceBetweenLinkDefinitionAndLink()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/EnsureExplicitNullableTypesTest.php
+++ b/tests/Rule/EnsureExplicitNullableTypesTest.php
@@ -31,7 +31,7 @@ final class EnsureExplicitNullableTypesTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new EnsureExplicitNullableTypes())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new EnsureExplicitNullableTypes()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/EnsureLinkBottomTest.php
+++ b/tests/Rule/EnsureLinkBottomTest.php
@@ -30,7 +30,7 @@ final class EnsureLinkBottomTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new EnsureLinkBottom())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new EnsureLinkBottom()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/EnsureLinkDefinitionContainsValidUrlTest.php
+++ b/tests/Rule/EnsureLinkDefinitionContainsValidUrlTest.php
@@ -31,7 +31,7 @@ final class EnsureLinkDefinitionContainsValidUrlTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new EnsureLinkDefinitionContainsValidUrl())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new EnsureLinkDefinitionContainsValidUrl()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/EnsureOrderOfCodeBlocksInConfigurationBlockTest.php
+++ b/tests/Rule/EnsureOrderOfCodeBlocksInConfigurationBlockTest.php
@@ -31,7 +31,7 @@ final class EnsureOrderOfCodeBlocksInConfigurationBlockTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new EnsureOrderOfCodeBlocksInConfigurationBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new EnsureOrderOfCodeBlocksInConfigurationBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/EnsurePhpReferenceSyntaxTest.php
+++ b/tests/Rule/EnsurePhpReferenceSyntaxTest.php
@@ -30,7 +30,7 @@ final class EnsurePhpReferenceSyntaxTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new EnsurePhpReferenceSyntax())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new EnsurePhpReferenceSyntax()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/EnsureShorthandColonsTest.php
+++ b/tests/Rule/EnsureShorthandColonsTest.php
@@ -30,7 +30,7 @@ final class EnsureShorthandColonsTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new EnsureShorthandColons())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new EnsureShorthandColons()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/ExtendAbstractAdminTest.php
+++ b/tests/Rule/ExtendAbstractAdminTest.php
@@ -30,7 +30,7 @@ final class ExtendAbstractAdminTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new ExtendAbstractAdmin())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new ExtendAbstractAdmin()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/ExtendAbstractControllerTest.php
+++ b/tests/Rule/ExtendAbstractControllerTest.php
@@ -30,7 +30,7 @@ final class ExtendAbstractControllerTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new ExtendAbstractController())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new ExtendAbstractController()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/ExtendControllerTest.php
+++ b/tests/Rule/ExtendControllerTest.php
@@ -30,7 +30,7 @@ final class ExtendControllerTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new ExtendController())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new ExtendController()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/ExtensionXlfInsteadOfXliffTest.php
+++ b/tests/Rule/ExtensionXlfInsteadOfXliffTest.php
@@ -30,7 +30,7 @@ final class ExtensionXlfInsteadOfXliffTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new ExtensionXlfInsteadOfXliff())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new ExtensionXlfInsteadOfXliff()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/FilenameUsesDashesOnlyTest.php
+++ b/tests/Rule/FilenameUsesDashesOnlyTest.php
@@ -35,7 +35,7 @@ final class FilenameUsesDashesOnlyTest extends UnitTestCase
 
         self::assertEquals(
             $expected,
-            (new FilenameUsesDashesOnly())->check($fileInfo),
+            new FilenameUsesDashesOnly()->check($fileInfo),
         );
     }
 

--- a/tests/Rule/FilenameUsesUnderscoresOnlyTest.php
+++ b/tests/Rule/FilenameUsesUnderscoresOnlyTest.php
@@ -33,7 +33,7 @@ final class FilenameUsesUnderscoresOnlyTest extends UnitTestCase
         $fileInfo = $this->createMock(\SplFileInfo::class);
         $fileInfo->method('getFilename')->willReturn($filename);
 
-        $violation = (new FilenameUsesUnderscoresOnly())->check($fileInfo);
+        $violation = new FilenameUsesUnderscoresOnly()->check($fileInfo);
         self::assertEquals(
             $expected,
             $violation,

--- a/tests/Rule/FinalAdminClassesTest.php
+++ b/tests/Rule/FinalAdminClassesTest.php
@@ -36,7 +36,7 @@ final class FinalAdminClassesTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new FinalAdminClasses())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new FinalAdminClasses()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/FinalAdminExtensionClassesTest.php
+++ b/tests/Rule/FinalAdminExtensionClassesTest.php
@@ -30,7 +30,7 @@ final class FinalAdminExtensionClassesTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new FinalAdminExtensionClasses())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new FinalAdminExtensionClasses()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/IndentionTest.php
+++ b/tests/Rule/IndentionTest.php
@@ -364,7 +364,7 @@ RST
     {
         self::assertSame(
             $expected,
-            (new Indention())->isPartOrMultilineXmlComment($sample->lines, $sample->lineNumber),
+            new Indention()->isPartOrMultilineXmlComment($sample->lines, $sample->lineNumber),
         );
     }
 
@@ -431,7 +431,7 @@ RST
     {
         self::assertSame(
             $expected,
-            (new Indention())->isPartOrMultilineTwigComment($sample->lines, $sample->lineNumber),
+            new Indention()->isPartOrMultilineTwigComment($sample->lines, $sample->lineNumber),
         );
     }
 

--- a/tests/Rule/KernelInsteadOfAppKernelTest.php
+++ b/tests/Rule/KernelInsteadOfAppKernelTest.php
@@ -30,7 +30,7 @@ final class KernelInsteadOfAppKernelTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new KernelInsteadOfAppKernel())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new KernelInsteadOfAppKernel()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/LowercaseAsInUseStatementTest.php
+++ b/tests/Rule/LowercaseAsInUseStatementTest.php
@@ -30,7 +30,7 @@ final class LowercaseAsInUseStatementTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new LowercaseAsInUseStatements())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new LowercaseAsInUseStatements()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/MaxColonsTest.php
+++ b/tests/Rule/MaxColonsTest.php
@@ -30,7 +30,7 @@ final class MaxColonsTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new MaxColons())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new MaxColons()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoAdminYamlTest.php
+++ b/tests/Rule/NoAdminYamlTest.php
@@ -30,7 +30,7 @@ final class NoAdminYamlTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoAdminYaml())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoAdminYaml()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoAttributeRedundantParenthesisTest.php
+++ b/tests/Rule/NoAttributeRedundantParenthesisTest.php
@@ -30,7 +30,7 @@ final class NoAttributeRedundantParenthesisTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoAttributeRedundantParenthesis())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoAttributeRedundantParenthesis()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoBashPromptTest.php
+++ b/tests/Rule/NoBashPromptTest.php
@@ -30,7 +30,7 @@ final class NoBashPromptTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoBashPrompt())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoBashPrompt()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoBlankLineAfterFilepathInCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInCodeBlockTest.php
@@ -35,7 +35,7 @@ final class NoBlankLineAfterFilepathInCodeBlockTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoBlankLineAfterFilepathInCodeBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoBlankLineAfterFilepathInCodeBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoBlankLineAfterFilepathInPhpCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInPhpCodeBlockTest.php
@@ -30,7 +30,7 @@ final class NoBlankLineAfterFilepathInPhpCodeBlockTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoBlankLineAfterFilepathInPhpCodeBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoBlankLineAfterFilepathInPhpCodeBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoBlankLineAfterFilepathInTwigCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInTwigCodeBlockTest.php
@@ -30,7 +30,7 @@ final class NoBlankLineAfterFilepathInTwigCodeBlockTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoBlankLineAfterFilepathInTwigCodeBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoBlankLineAfterFilepathInTwigCodeBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoBlankLineAfterFilepathInXmlCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInXmlCodeBlockTest.php
@@ -30,7 +30,7 @@ final class NoBlankLineAfterFilepathInXmlCodeBlockTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoBlankLineAfterFilepathInXmlCodeBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoBlankLineAfterFilepathInXmlCodeBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoBlankLineAfterFilepathInYamlCodeBlockTest.php
+++ b/tests/Rule/NoBlankLineAfterFilepathInYamlCodeBlockTest.php
@@ -30,7 +30,7 @@ final class NoBlankLineAfterFilepathInYamlCodeBlockTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoBlankLineAfterFilepathInYamlCodeBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoBlankLineAfterFilepathInYamlCodeBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoBracketsInMethodDirectiveTest.php
+++ b/tests/Rule/NoBracketsInMethodDirectiveTest.php
@@ -30,7 +30,7 @@ final class NoBracketsInMethodDirectiveTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoBracketsInMethodDirective())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoBracketsInMethodDirective()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoBrokenRefDirectiveTest.php
+++ b/tests/Rule/NoBrokenRefDirectiveTest.php
@@ -30,7 +30,7 @@ final class NoBrokenRefDirectiveTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoBrokenRefDirective())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoBrokenRefDirective()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoComposerReqTest.php
+++ b/tests/Rule/NoComposerReqTest.php
@@ -30,7 +30,7 @@ final class NoComposerReqTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoComposerReq())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoComposerReq()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoContractionTest.php
+++ b/tests/Rule/NoContractionTest.php
@@ -31,7 +31,7 @@ final class NoContractionTest extends UnitTestCase
         $configuredRules = [];
 
         foreach (NoContraction::getList() as $search => $message) {
-            $configuredRules[] = (new NoContraction())->configure($search, $message);
+            $configuredRules[] = new NoContraction()->configure($search, $message);
         }
 
         $violations = [];

--- a/tests/Rule/NoDirectiveAfterShorthandTest.php
+++ b/tests/Rule/NoDirectiveAfterShorthandTest.php
@@ -31,7 +31,7 @@ final class NoDirectiveAfterShorthandTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoDirectiveAfterShorthand())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoDirectiveAfterShorthand()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoDuplicateUseStatementsTest.php
+++ b/tests/Rule/NoDuplicateUseStatementsTest.php
@@ -30,7 +30,7 @@ final class NoDuplicateUseStatementsTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoDuplicateUseStatements())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoDuplicateUseStatements()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoEmptyDirectiveTest.php
+++ b/tests/Rule/NoEmptyDirectiveTest.php
@@ -43,7 +43,7 @@ final class NoEmptyDirectiveTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoEmptyDirective())
+            new NoEmptyDirective()
                 ->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }

--- a/tests/Rule/NoExplicitUseOfCodeBlockPhpTest.php
+++ b/tests/Rule/NoExplicitUseOfCodeBlockPhpTest.php
@@ -31,7 +31,7 @@ final class NoExplicitUseOfCodeBlockPhpTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoExplicitUseOfCodeBlockPhp())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoExplicitUseOfCodeBlockPhp()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoFootnotesTest.php
+++ b/tests/Rule/NoFootnotesTest.php
@@ -30,7 +30,7 @@ final class NoFootnotesTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoFootnotes())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoFootnotes()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoInheritdocInCodeExamplesTest.php
+++ b/tests/Rule/NoInheritdocInCodeExamplesTest.php
@@ -30,7 +30,7 @@ final class NoInheritdocInCodeExamplesTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoInheritdocInCodeExamples())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoInheritdocInCodeExamples()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoMergeConflictTest.php
+++ b/tests/Rule/NoMergeConflictTest.php
@@ -30,7 +30,7 @@ final class NoMergeConflictTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoMergeConflict())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoMergeConflict()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoNamespaceAfterUseStatementsTest.php
+++ b/tests/Rule/NoNamespaceAfterUseStatementsTest.php
@@ -30,7 +30,7 @@ final class NoNamespaceAfterUseStatementsTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoNamespaceAfterUseStatements())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoNamespaceAfterUseStatements()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoNonBreakingSpaceTest.php
+++ b/tests/Rule/NoNonBreakingSpaceTest.php
@@ -30,7 +30,7 @@ final class NoNonBreakingSpaceTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoNonBreakingSpace())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoNonBreakingSpace()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoPhpOpenTagInCodeBlockPhpDirectiveTest.php
+++ b/tests/Rule/NoPhpOpenTagInCodeBlockPhpDirectiveTest.php
@@ -30,7 +30,7 @@ final class NoPhpOpenTagInCodeBlockPhpDirectiveTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoPhpOpenTagInCodeBlockPhpDirective())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoPhpOpenTagInCodeBlockPhpDirective()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoPhpPrefixBeforeBinConsoleTest.php
+++ b/tests/Rule/NoPhpPrefixBeforeBinConsoleTest.php
@@ -30,7 +30,7 @@ final class NoPhpPrefixBeforeBinConsoleTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoPhpPrefixBeforeBinConsole())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoPhpPrefixBeforeBinConsole()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoPhpPrefixBeforeComposerTest.php
+++ b/tests/Rule/NoPhpPrefixBeforeComposerTest.php
@@ -30,7 +30,7 @@ final class NoPhpPrefixBeforeComposerTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoPhpPrefixBeforeComposer())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoPhpPrefixBeforeComposer()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoRelativeDocPathTest.php
+++ b/tests/Rule/NoRelativeDocPathTest.php
@@ -30,7 +30,7 @@ final class NoRelativeDocPathTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoRelativeDocPath())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoRelativeDocPath()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoSpaceBeforeSelfXmlClosingTagTest.php
+++ b/tests/Rule/NoSpaceBeforeSelfXmlClosingTagTest.php
@@ -30,7 +30,7 @@ final class NoSpaceBeforeSelfXmlClosingTagTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoSpaceBeforeSelfXmlClosingTag())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoSpaceBeforeSelfXmlClosingTag()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NoTypographicQuotesTest.php
+++ b/tests/Rule/NoTypographicQuotesTest.php
@@ -29,7 +29,7 @@ final class NoTypographicQuotesTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NoTypographicQuotes())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NoTypographicQuotes()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/NonStaticPhpunitAssertionsTest.php
+++ b/tests/Rule/NonStaticPhpunitAssertionsTest.php
@@ -30,7 +30,7 @@ final class NonStaticPhpunitAssertionsTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new NonStaticPhpunitAssertions())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new NonStaticPhpunitAssertions()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/OnlyBackslashesInNamespaceInPhpCodeBlockTest.php
+++ b/tests/Rule/OnlyBackslashesInNamespaceInPhpCodeBlockTest.php
@@ -30,7 +30,7 @@ final class OnlyBackslashesInNamespaceInPhpCodeBlockTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new OnlyBackslashesInNamespaceInPhpCodeBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new OnlyBackslashesInNamespaceInPhpCodeBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlockTest.php
+++ b/tests/Rule/OnlyBackslashesInUseStatementsInPhpCodeBlockTest.php
@@ -30,7 +30,7 @@ final class OnlyBackslashesInUseStatementsInPhpCodeBlockTest extends UnitTestCas
     {
         self::assertEquals(
             $expected,
-            (new OnlyBackslashesInUseStatementsInPhpCodeBlock())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new OnlyBackslashesInUseStatementsInPhpCodeBlock()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/OrderedUseStatementsTest.php
+++ b/tests/Rule/OrderedUseStatementsTest.php
@@ -30,7 +30,7 @@ final class OrderedUseStatementsTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new OrderedUseStatements())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new OrderedUseStatements()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/PhpOpenTagInCodeBlockPhpDirectiveTest.php
+++ b/tests/Rule/PhpOpenTagInCodeBlockPhpDirectiveTest.php
@@ -30,7 +30,7 @@ final class PhpOpenTagInCodeBlockPhpDirectiveTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new PhpOpenTagInCodeBlockPhpDirective())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new PhpOpenTagInCodeBlockPhpDirective()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/PhpPrefixBeforeBinConsoleTest.php
+++ b/tests/Rule/PhpPrefixBeforeBinConsoleTest.php
@@ -30,7 +30,7 @@ final class PhpPrefixBeforeBinConsoleTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new PhpPrefixBeforeBinConsole())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new PhpPrefixBeforeBinConsole()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/RemoveTrailingWhitespaceTest.php
+++ b/tests/Rule/RemoveTrailingWhitespaceTest.php
@@ -30,7 +30,7 @@ final class RemoveTrailingWhitespaceTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new RemoveTrailingWhitespace())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new RemoveTrailingWhitespace()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/ReplaceCodeBlockTypesTest.php
+++ b/tests/Rule/ReplaceCodeBlockTypesTest.php
@@ -31,7 +31,7 @@ final class ReplaceCodeBlockTypesTest extends UnitTestCase
         $configuredRules = [];
 
         foreach (ReplaceCodeBlockTypes::getList() as $search => $message) {
-            $configuredRules[] = (new ReplaceCodeBlockTypes())->configure($search, $message);
+            $configuredRules[] = new ReplaceCodeBlockTypes()->configure($search, $message);
         }
 
         $violations = [];

--- a/tests/Rule/ReplacementTest.php
+++ b/tests/Rule/ReplacementTest.php
@@ -31,7 +31,7 @@ final class ReplacementTest extends UnitTestCase
         $configuredRules = [];
 
         foreach (Replacement::getList() as $search => $message) {
-            $configuredRules[] = (new Replacement())->configure($search, $message);
+            $configuredRules[] = new Replacement()->configure($search, $message);
         }
 
         $violations = [];

--- a/tests/Rule/ShortArraySyntaxTest.php
+++ b/tests/Rule/ShortArraySyntaxTest.php
@@ -30,7 +30,7 @@ final class ShortArraySyntaxTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new ShortArraySyntax())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new ShortArraySyntax()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/SpaceBeforeSelfXmlClosingTagTest.php
+++ b/tests/Rule/SpaceBeforeSelfXmlClosingTagTest.php
@@ -30,7 +30,7 @@ final class SpaceBeforeSelfXmlClosingTagTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new SpaceBeforeSelfXmlClosingTag())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new SpaceBeforeSelfXmlClosingTag()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/SpaceBetweenLabelAndLinkInDocTest.php
+++ b/tests/Rule/SpaceBetweenLabelAndLinkInDocTest.php
@@ -30,7 +30,7 @@ final class SpaceBetweenLabelAndLinkInDocTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new SpaceBetweenLabelAndLinkInDoc())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new SpaceBetweenLabelAndLinkInDoc()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/SpaceBetweenLabelAndLinkInRefTest.php
+++ b/tests/Rule/SpaceBetweenLabelAndLinkInRefTest.php
@@ -30,7 +30,7 @@ final class SpaceBetweenLabelAndLinkInRefTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new SpaceBetweenLabelAndLinkInRef())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new SpaceBetweenLabelAndLinkInRef()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/StringReplacementTest.php
+++ b/tests/Rule/StringReplacementTest.php
@@ -33,7 +33,7 @@ final class StringReplacementTest extends UnitTestCase
         $configuredRules = [];
 
         foreach (StringReplacement::getList() as $search => $message) {
-            $configuredRules[] = (new StringReplacement())->configure($search, $message);
+            $configuredRules[] = new StringReplacement()->configure($search, $message);
         }
 
         $violations = [];

--- a/tests/Rule/TitleUnderlineLengthMustMatchTitleLengthTest.php
+++ b/tests/Rule/TitleUnderlineLengthMustMatchTitleLengthTest.php
@@ -30,7 +30,7 @@ final class TitleUnderlineLengthMustMatchTitleLengthTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new TitleUnderlineLengthMustMatchTitleLength())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new TitleUnderlineLengthMustMatchTitleLength()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/TypoTest.php
+++ b/tests/Rule/TypoTest.php
@@ -32,7 +32,7 @@ final class TypoTest extends UnitTestCase
         $configuredRules = [];
 
         foreach (Typo::getList() as $search => $message) {
-            $configuredRules[] = (new Typo())->configure($search, $message);
+            $configuredRules[] = new Typo()->configure($search, $message);
         }
 
         $violations = [];

--- a/tests/Rule/UnusedLinksTest.php
+++ b/tests/Rule/UnusedLinksTest.php
@@ -31,7 +31,7 @@ final class UnusedLinksTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new UnusedLinks())->check($sample->lines, 'filename'),
+            new UnusedLinks()->check($sample->lines, 'filename'),
         );
     }
 

--- a/tests/Rule/UseDeprecatedDirectiveInsteadOfVersionaddedTest.php
+++ b/tests/Rule/UseDeprecatedDirectiveInsteadOfVersionaddedTest.php
@@ -31,7 +31,7 @@ final class UseDeprecatedDirectiveInsteadOfVersionaddedTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new UseDeprecatedDirectiveInsteadOfVersionadded())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new UseDeprecatedDirectiveInsteadOfVersionadded()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/UseHttpsXsdUrlsTest.php
+++ b/tests/Rule/UseHttpsXsdUrlsTest.php
@@ -30,7 +30,7 @@ final class UseHttpsXsdUrlsTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new UseHttpsXsdUrls())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new UseHttpsXsdUrls()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
+++ b/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php
@@ -30,7 +30,7 @@ final class UseNamedConstructorWithoutNewKeywordRuleTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new UseNamedConstructorWithoutNewKeywordRule())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new UseNamedConstructorWithoutNewKeywordRule()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/ValidInlineHighlightedNamespacesTest.php
+++ b/tests/Rule/ValidInlineHighlightedNamespacesTest.php
@@ -30,7 +30,7 @@ final class ValidInlineHighlightedNamespacesTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new ValidInlineHighlightedNamespaces())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new ValidInlineHighlightedNamespaces()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/ValidUseStatementsTest.php
+++ b/tests/Rule/ValidUseStatementsTest.php
@@ -30,7 +30,7 @@ final class ValidUseStatementsTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new ValidUseStatements())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new ValidUseStatements()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/VersionaddedDirectiveShouldHaveVersionTest.php
+++ b/tests/Rule/VersionaddedDirectiveShouldHaveVersionTest.php
@@ -31,7 +31,7 @@ final class VersionaddedDirectiveShouldHaveVersionTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new VersionaddedDirectiveShouldHaveVersion(new VersionParser()))
+            new VersionaddedDirectiveShouldHaveVersion(new VersionParser())
                 ->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }

--- a/tests/Rule/YamlInsteadOfYmlSuffixTest.php
+++ b/tests/Rule/YamlInsteadOfYmlSuffixTest.php
@@ -30,7 +30,7 @@ final class YamlInsteadOfYmlSuffixTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new YamlInsteadOfYmlSuffix())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new YamlInsteadOfYmlSuffix()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/YarnDevOptionAtTheEndTest.php
+++ b/tests/Rule/YarnDevOptionAtTheEndTest.php
@@ -30,7 +30,7 @@ final class YarnDevOptionAtTheEndTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new YarnDevOptionAtTheEnd())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new YarnDevOptionAtTheEnd()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 

--- a/tests/Rule/YarnDevOptionNotAtTheEndTest.php
+++ b/tests/Rule/YarnDevOptionNotAtTheEndTest.php
@@ -30,7 +30,7 @@ final class YarnDevOptionNotAtTheEndTest extends UnitTestCase
     {
         self::assertEquals(
             $expected,
-            (new YarnDevOptionNotAtTheEnd())->check($sample->lines, $sample->lineNumber, 'filename'),
+            new YarnDevOptionNotAtTheEnd()->check($sample->lines, $sample->lineNumber, 'filename'),
         );
     }
 


### PR DESCRIPTION
Bumps all Symfony components from 7.4 to 8.1 (needs PHP >= 8.4.1, and this project already requires `^8.5`).

Since Symfony 8.0, `OptionsResolverIntrospector::getDefault()` returns the raw closure of a nested options definition instead of the resolved array, which made `bin/doctor-rst rules` fail with *Object of class Closure could not be converted to string*; `RulesCommand` now falls back to an empty array in that case, keeping the generated `docs/rules.md` unchanged.

Rector's `NewMethodCallWithoutParenthesesRector` and php-cs-fixer's `new_expression_parentheses` rule were configured to opposite ends, so each tool kept reverting the other's work and `make refactoring` never converged — `new_expression_parentheses` is now set to `use_parentheses: false` (the fixer's own default) so both agree on `new Foo()->bar()`, and the resulting change is applied across 99 files.

Finally, three rules that Rector reported as never registered are removed from `->withSkip()` in `rector.php`.

Rector, php-cs-fixer, PHPStan, `composer-require-checker` and `composer-unused` are all clean, and `docs/rules.md` is unchanged; the test suite is left to CI.