### PR TITLE
Make the Generate and Refactoring jobs work on pull requests from forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,22 +140,11 @@ jobs:
                     - "8.5"
 
         steps:
-            # workaround for missing secret in fork PRs - see https://github.com/actions/checkout/issues/298
-            # see https://github.com/rectorphp/rector/commit/d395e1c28b8e6a56711dcc2e10490a82965850e4
-            -   if: github.actor != 'dependabot[bot]'
+            # nothing is committed back here, so the default checkout is enough; naming the
+            # branch would fail on a pull request from a fork, whose branch only exists there
+            -
                 name: "Checkout"
                 uses: "actions/checkout@v7"
-                with:
-                    ref: "${{ github.head_ref }}"
-                    # Must be used to be able to commit changed files
-                    token: "${{ secrets.GITHUB_TOKEN }}"
-
-            # in forks, the token is not available - so we cannot use it
-            -   if: github.actor == 'dependabot[bot]'
-                name: "Checkout"
-                uses: "actions/checkout@v7"
-                with:
-                    ref: "${{ github.head_ref }}"
 
             -
                 name: "Install PHP with extensions"

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -21,7 +21,13 @@ jobs:
                     - "8.5"
 
         steps:
-            -
+            # a pull request from a fork has its branch over there, so it can neither be
+            # checked out by name from here nor be pushed to with this token
+            -   if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+                name: "Checkout"
+                uses: "actions/checkout@v7"
+
+            -   if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
                 name: "Checkout"
                 uses: "actions/checkout@v7"
                 with:
@@ -46,7 +52,7 @@ jobs:
                 name: "Regenerate workflow images"
                 run: php bin/doctor-rst rules > docs/rules.md
 
-            -
+            -   if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
                 name: "Commit regenerated docs/rules.md file"
                 uses: "stefanzweifel/git-auto-commit-action@v7.2.0"
                 with:
@@ -55,3 +61,11 @@ jobs:
                     commit_message: "Fix: Regenerate docs/rules.md files"
                     commit_user_email: "${{ env.COMMITTER_EMAIL }}"
                     commit_user_name: "${{ env.COMMITTER_NAME }}"
+
+            # the file cannot be fixed up on a fork's branch, so the contributor is told to
+            # regenerate it instead of the job silently doing nothing
+            -   if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+                name: "Check docs/rules.md is up to date"
+                run: |
+                    git diff --exit-code -- docs/rules.md \
+                        || (echo '::error file=docs/rules.md::Run "php bin/doctor-rst rules > docs/rules.md" and commit the result.' && exit 1)


### PR DESCRIPTION
Follows up on your "PR welcome" in #2372.

Both jobs checked out `github.head_ref`, a bare branch name resolved against this repository. On a pull request from a fork the branch only exists over there, so the fetch found nothing and the job failed before reaching Rector or the generator:

```
git fetch --depth=1 origin +refs/heads/<branch>*:...
The process '/usr/bin/git' failed with exit code 1
```

`Refactoring` already carried a workaround, but it was gated on `github.actor == 'dependabot[bot]'`, and dependabot's branches live in this repository anyway, so it never covered an outside contributor.

`Refactoring` commits nothing back, so it now just uses the default checkout, which works everywhere and picks up the merge commit.

`Generate` does commit back, and cannot push to a fork's branch whatever the checkout. So on a fork's pull request it now regenerates `docs/rules.md` and fails with the command to run, instead of the job being broken. Everywhere else it behaves exactly as before.

This pull request comes from a fork, so its own checks are the test: both jobs should go green rather than fail at checkout.
