### PR TITLE
Add a use_single_backticks_for_ref_and_doc rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -102,6 +102,7 @@
 * [use_double_backticks_for_inline_literals](#use_double_backticks_for_inline_literals)
 * [use_https_xsd_urls](#use_https_xsd_urls)
 * [use_named_constructor_without_new_keyword_rule](#use_named_constructor_without_new_keyword_rule)
+* [use_single_backticks_for_ref_and_doc](#use_single_backticks_for_ref_and_doc)
 * [valid_inline_highlighted_namespaces](#valid_inline_highlighted_namespaces)
 * [valid_use_statements](#valid_use_statements)
 * [versionadded_directive_major_version](#versionadded_directive_major_version)
@@ -1841,6 +1842,29 @@ new Uuid::fromString()
 
 - Rule class: [App\Rule\UseNamedConstructorWithoutNewKeywordRule](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/UseNamedConstructorWithoutNewKeywordRule.php)
 - Test class: [App\Tests\Rule\UseNamedConstructorWithoutNewKeywordRuleTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/UseNamedConstructorWithoutNewKeywordRuleTest.php)
+
+## `use_single_backticks_for_ref_and_doc`
+
+  > _Ensure the content of :ref: and :doc: directives is surrounded by a single backtick._
+
+#### Groups [`@Sonata`, `@Symfony`]
+
+##### Valid Examples :+1:
+
+```rst
+:doc:`Route </routing>`
+```
+
+##### Invalid Examples :-1:
+
+```rst
+:ref:`DeprecatedAlias <routing-alias-deprecation>``
+```
+
+#### References
+
+- Rule class: [App\Rule\UseSingleBackticksForRefAndDoc](https://github.com/OskarStark/doctor-rst/blob/develop/src/Rule/UseSingleBackticksForRefAndDoc.php)
+- Test class: [App\Tests\Rule\UseSingleBackticksForRefAndDocTest](https://github.com/OskarStark/doctor-rst/blob/develop/tests/Rule/UseSingleBackticksForRefAndDocTest.php)
 
 ## `valid_inline_highlighted_namespaces`
 

--- a/src/Rule/UseSingleBackticksForRefAndDoc.php
+++ b/src/Rule/UseSingleBackticksForRefAndDoc.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Rule;
+
+use App\Attribute\Rule\Description;
+use App\Attribute\Rule\InvalidExample;
+use App\Attribute\Rule\ValidExample;
+use App\Rst\RstParser;
+use App\Traits\DirectiveTrait;
+use App\Value\Lines;
+use App\Value\NullViolation;
+use App\Value\RuleGroup;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+
+#[Description('Ensure the content of :ref: and :doc: directives is surrounded by a single backtick.')]
+#[InvalidExample(':ref:`DeprecatedAlias <routing-alias-deprecation>``')]
+#[ValidExample(':doc:`Route </routing>`')]
+final class UseSingleBackticksForRefAndDoc extends AbstractRule implements LineContentRule
+{
+    use DirectiveTrait;
+
+    /**
+     * Matches a :ref: or :doc: directive with its surrounding backticks.
+     *
+     * "before" tells apart a directive shown inside an inline literal, as in
+     * ``:ref:`Foo```, from a directive whose own backticks are doubled.
+     */
+    private const string PATTERN = '/(?P<before>`*):(?P<role>ref|doc):(?P<open>`+)(?P<content>[^`]*)(?P<close>`+)/';
+
+    public static function getGroups(): array
+    {
+        return [
+            RuleGroup::Sonata(),
+            RuleGroup::Symfony(),
+        ];
+    }
+
+    public function check(Lines $lines, int $number, string $filename): ViolationInterface
+    {
+        $lines->seek($number);
+        $line = $lines->current();
+
+        if ($this->in(RstParser::DIRECTIVE_CODE_BLOCK, $lines, $number)) {
+            return NullViolation::create();
+        }
+
+        if (!preg_match_all(self::PATTERN, $line->raw()->toString(), $matches, \PREG_SET_ORDER)) {
+            return NullViolation::create();
+        }
+
+        foreach ($matches as $match) {
+            // the directive is quoted as an inline literal, its backticks are not its own
+            if ('' !== $match['before']) {
+                continue;
+            }
+
+            if (1 === \strlen($match['open']) && 1 === \strlen($match['close'])) {
+                continue;
+            }
+
+            return Violation::from(
+                \sprintf(
+                    'Please use a single backtick around "%s" inside :%s: directive',
+                    $match['content'],
+                    $match['role'],
+                ),
+                $filename,
+                $number + 1,
+                $line,
+            );
+        }
+
+        return NullViolation::create();
+    }
+}

--- a/tests/Rule/UseSingleBackticksForRefAndDocTest.php
+++ b/tests/Rule/UseSingleBackticksForRefAndDocTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Rule;
+
+use App\Rule\UseSingleBackticksForRefAndDoc;
+use App\Tests\RstSample;
+use App\Tests\UnitTestCase;
+use App\Value\NullViolation;
+use App\Value\Violation;
+use App\Value\ViolationInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class UseSingleBackticksForRefAndDocTest extends UnitTestCase
+{
+    #[Test]
+    #[DataProvider('checkProvider')]
+    public function check(ViolationInterface $expected, RstSample $sample): void
+    {
+        self::assertEquals(
+            $expected,
+            new UseSingleBackticksForRefAndDoc()->check($sample->lines, $sample->lineNumber, 'filename'),
+        );
+    }
+
+    /**
+     * @return \Generator<string, array{0: ViolationInterface, 1: RstSample}>
+     */
+    public static function checkProvider(): iterable
+    {
+        yield 'closing backtick is doubled' => [
+            Violation::from(
+                'Please use a single backtick around "DeprecatedAlias <routing-alias-deprecation>" inside :ref: directive',
+                'filename',
+                1,
+                ':ref:`DeprecatedAlias <routing-alias-deprecation>``',
+            ),
+            new RstSample(':ref:`DeprecatedAlias <routing-alias-deprecation>``'),
+        ];
+
+        yield 'opening backtick is doubled' => [
+            Violation::from(
+                'Please use a single backtick around "Route </routing>" inside :doc: directive',
+                'filename',
+                1,
+                ':doc:``Route </routing>`',
+            ),
+            new RstSample(':doc:``Route </routing>`'),
+        ];
+
+        yield 'both backticks are doubled' => [
+            Violation::from(
+                'Please use a single backtick around "Route </routing>" inside :doc: directive',
+                'filename',
+                1,
+                ':doc:``Route </routing>``',
+            ),
+            new RstSample(':doc:``Route </routing>``'),
+        ];
+
+        yield 'the violation is reported in the middle of a sentence' => [
+            Violation::from(
+                'Please use a single backtick around "Route </routing>" inside :doc: directive',
+                'filename',
+                1,
+                'Read the :doc:`Route </routing>`` article for details.',
+            ),
+            new RstSample('Read the :doc:`Route </routing>`` article for details.'),
+        ];
+
+        yield 'valid :ref: directive' => [
+            NullViolation::create(),
+            new RstSample(':ref:`receiving them via a worker <messenger-worker>`'),
+        ];
+
+        yield 'valid :doc: directive' => [
+            NullViolation::create(),
+            new RstSample(':doc:`Route </routing>`'),
+        ];
+
+        yield 'valid directive next to an inline literal' => [
+            NullViolation::create(),
+            new RstSample('See :doc:`Route </routing>` and use ``kernel.project_dir``.'),
+        ];
+
+        yield 'the directive itself is shown as an inline literal' => [
+            NullViolation::create(),
+            new RstSample('Write ``:ref:`Foo``` to link to it.'),
+        ];
+
+        yield 'directive inside a code block' => [
+            NullViolation::create(),
+            new RstSample(<<<'RST'
+                .. code-block:: rst
+
+                    :ref:`DeprecatedAlias <routing-alias-deprecation>``
+                RST, 2),
+        ];
+    }
+}


### PR DESCRIPTION
Closes #2264.

Adds `use_single_backticks_for_ref_and_doc`, which reports a `:ref:` or `:doc:` directive whose content is not surrounded by exactly one backtick:

```rst
* :ref:`DeprecatedAlias <routing-alias-deprecation>``
* :doc:`Route </routing>`
```

The first line is reported, the second is fine. Doubled opening backticks are reported too, since the mistake goes both ways.

### The two cases worth not flagging

A directive quoted as an inline literal, ```` ``:ref:`Foo``` ````, has doubled backticks that are not its own, so the rule looks at what precedes the directive and skips those. And code blocks are skipped through `DirectiveTrait`, so a `.. code-block:: rst` showing the mistake on purpose stays quiet. Both have a test.

### Verification

Beyond the 9 unit tests, I ran the rule over the whole symfony-docs `8.2` branch: no violation, no false positive. On a small sample carrying the exact line from the issue, it reports that line and leaves the valid directive, the quoted one and the one inside a code block alone.

`docs/rules.md` is regenerated with `php bin/doctor-rst rules`, PHPStan and PHP-CS-Fixer are clean, and the 2086 tests pass.

### Two things for you to decide

The name follows `use_double_backticks_for_inline_literals`, but I am not attached to it. And the rule handles `:ref:` and `:doc:` together, where the repository usually pairs them as two rules (`space_between_label_and_link_in_ref` / `..._in_doc`); the issue framed it as one rule, so that is what I did. Happy to split it, rename it, or widen it to the other roles if you would rather.
