### PR TITLE
Do not report the indention of simple table cells

### DIFF
--- a/src/Rule/Indention.php
+++ b/src/Rule/Indention.php
@@ -19,6 +19,7 @@ use App\Helper\XmlHelper;
 use App\Rst\RstParser;
 use App\Traits\DirectiveTrait;
 use App\Traits\ListTrait;
+use App\Traits\TableTrait;
 use App\Value\Lines;
 use App\Value\NullViolation;
 use App\Value\RuleGroup;
@@ -30,6 +31,7 @@ final class Indention extends AbstractRule implements Configurable, LineContentR
 {
     use DirectiveTrait;
     use ListTrait;
+    use TableTrait;
     private int $size;
 
     public function configureOptions(OptionsResolver $resolver): OptionsResolver
@@ -68,6 +70,7 @@ final class Indention extends AbstractRule implements Configurable, LineContentR
             || $this->isPartOfFootnote($lines, $number)
             || $this->isPartOfRstComment($lines, $number)
             || $this->isPartOfLineNumberAnnotation($lines, $number)
+            || $this->isPartOfSimpleTable($lines, $number)
             || $this->in(RstParser::DIRECTIVE_INDEX, $lines, $number)
             || $this->in(RstParser::DIRECTIVE_FIGURE, $lines, $number)
             || $this->in(RstParser::DIRECTIVE_IMAGE, $lines, $number)

--- a/src/Traits/TableTrait.php
+++ b/src/Traits/TableTrait.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of DOCtor-RST.
+ *
+ * (c) Oskar Stark <oskarstark@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Traits;
+
+use App\Rst\RstParser;
+use App\Value\Lines;
+
+trait TableTrait
+{
+    /**
+     * The columns of a simple table are aligned under its borders, so its cells and the
+     * continuation lines of those cells follow the width of the columns rather than the
+     * indention of the document.
+     */
+    private function isPartOfSimpleTable(Lines $lines, int $number): bool
+    {
+        return $this->hasTableBorderAbove($lines, $number) && $this->hasTableBorderBelow($lines, $number);
+    }
+
+    private function hasTableBorderAbove(Lines $lines, int $number): bool
+    {
+        for ($i = $number - 1; 0 <= $i; --$i) {
+            $lines->seek($i);
+
+            if ($lines->current()->isBlank()) {
+                return false;
+            }
+
+            if (RstParser::isTable($lines->current())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasTableBorderBelow(Lines $lines, int $number): bool
+    {
+        $lines->seek($number);
+        $lines->next();
+
+        while ($lines->valid()) {
+            if ($lines->current()->isBlank()) {
+                return false;
+            }
+
+            if (RstParser::isTable($lines->current())) {
+                return true;
+            }
+
+            $lines->next();
+        }
+
+        return false;
+    }
+}

--- a/tests/Rule/IndentionTest.php
+++ b/tests/Rule/IndentionTest.php
@@ -356,6 +356,45 @@ RST
 RST
                 , 5),
         ];
+
+        $simple_table_example = <<<'RST'
+=================  =====================================================================================
+Value              Recommended situation
+=================  =====================================================================================
+``max[total]=0``   Recommended for actively maintained projects with robust/no dependencies
+``max[direct]=0``  Recommended for projects with dependencies that fail to keep up with new deprecations
+``max[self]=0``    Recommended for libraries that use the deprecation system themselves
+                   and cannot afford to use one of the modes above
+=================  =====================================================================================
+RST;
+
+        yield 'simple table cell' => [
+            NullViolation::create(),
+            4,
+            new RstSample($simple_table_example, 3),
+        ];
+
+        yield 'simple table cell continued on the next line' => [
+            NullViolation::create(),
+            4,
+            new RstSample($simple_table_example, 6),
+        ];
+
+        yield 'wrongly indented line right below a headline' => [
+            Violation::from(
+                'Please add 4 spaces for every indention.',
+                'filename',
+                3,
+                'Content',
+            ),
+            4,
+            new RstSample(<<<'RST'
+Headline
+========
+  Content
+RST
+                , 2),
+        ];
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #2279.

The columns of a simple table are aligned under its `=` borders, so a cell that spills over to the next line is indented to the width of its column, which is almost never a multiple of the configured size. `Indention` reported that as a violation. The workaround on the symfony-docs side was to exclude the whole file from the rule (symfony/symfony-docs@dd3df63), so the false positive is still costing that build.

A line is now skipped when it sits between two table borders with no blank line in between. Requiring a border on *both* sides is what keeps a genuinely misindented line right below a headline underline reported, since `RstParser::isTable()` matches that underline too. There is a test for it.

The exact table from the issue is used as the fixture, and the failing line is the one javiereguiluz reported.

One boundary worth naming: RST allows blank lines between the row groups of a simple table, and this stops at the first blank line, so a cell continued after such a blank line would still be reported. That shape does not appear in symfony-docs, and treating it properly would mean counting borders rather than looking at the neighbours, which felt like more machinery than the bug deserves. Happy to go further if you would rather cover it.
