### PR TITLE
Skip all code blocks in the ensure_attribute_between_backticks_in_content rule

### DIFF
--- a/src/Rule/EnsureAttributeBetweenBackticksInContent.php
+++ b/src/Rule/EnsureAttributeBetweenBackticksInContent.php
@@ -39,7 +39,7 @@ final class EnsureAttributeBetweenBackticksInContent extends AbstractRule implem
             return NullViolation::create();
         }
 
-        if ($this->in(RstParser::DIRECTIVE_CODE_BLOCK, $lines, $number, [RstParser::CODE_BLOCK_DIFF])) {
+        if ($this->in(RstParser::DIRECTIVE_CODE_BLOCK, $lines, $number)) {
             return NullViolation::create();
         }
 

--- a/tests/Rule/EnsureAttributeBetweenBackticksInContentTest.php
+++ b/tests/Rule/EnsureAttributeBetweenBackticksInContentTest.php
@@ -46,13 +46,46 @@ final class EnsureAttributeBetweenBackticksInContentTest extends UnitTestCase
             ];
         }
 
-        yield 'No violation for diff code-block' => [
+        foreach (['diff', 'terminal', 'yaml', 'text', 'twig'] as $type) {
+            yield \sprintf('No violation for code-block "%s"', $type) => [
+                NullViolation::create(),
+                new RstSample([
+                    \sprintf('.. code-block:: %s', $type),
+                    '',
+                    '    #[AsEventListener]',
+                ], 2),
+            ];
+        }
+
+        yield 'No violation for a console output listing an attribute' => [
             NullViolation::create(),
             new RstSample([
-                '.. code-block:: diff',
+                '.. code-block:: terminal',
                 '',
-                '    #[AsEventListener]',
-            ]),
+                '    $ php bin/console debug:messenger',
+                '',
+                '      Transports',
+                '      ----------',
+                '',
+                '      audit',
+                '          App\Message\DummyQuery (from #[AsMessage])',
+            ], 8),
+        ];
+
+        yield 'Has violation in content following a code-block' => [
+            Violation::from(
+                'Please ensure to use backticks "use #[MapEntity] attributes"',
+                'filename',
+                5,
+                'use #[MapEntity] attributes',
+            ),
+            new RstSample([
+                '.. code-block:: terminal',
+                '',
+                '    $ php bin/console debug:router',
+                '',
+                'use #[MapEntity] attributes',
+            ], 4),
         ];
 
         yield 'Has violation without backticks' => [


### PR DESCRIPTION
The rule only skipped `php` and `diff` code blocks, so an attribute inside any other code block was reported. symfony-docs hits it since symfony/symfony-docs#22926: the `debug:messenger` output in `messenger.rst` lists `App\Message\DummyQuery (from #[AsMessage])` inside a `.. code-block:: terminal`, and DOCtor-RST now fails on every `8.2` pull request.

`in()` was called with `[RstParser::CODE_BLOCK_DIFF]`, which restricts the match to diff blocks. Dropping the filter skips every code block, as #2170 did for `use_double_backticks_for_inline_literals`.

### Tests

The existing diff case built its `RstSample` without a line number, so it checked line 0, the `.. code-block::` line itself, and passed whatever the rule did. The new cases point at the attribute line: diff, terminal, yaml, text and twig, plus the `debug:messenger` output, and a guard showing that an attribute in the content right after a code block is still reported. Without the fix, the five non-diff cases fail. The PHP code block loop above has the same line 0 issue; I left it alone since fixing it means rewriting its samples, happy to do it here or separately.

### Verification

Running the patched rule over the symfony-docs `8.2` branch, `messenger.rst` is no longer reported (the remaining Tui violations are fixed by symfony/symfony-docs#22983). The 2095 tests pass, PHPStan and PHP-CS-Fixer are clean, and `docs/rules.md` needs no change.

symfony-docs pins `oskarstark/doctor-rst:1.83.0`, so it will need a bump once this is released.
