### PR TITLE
Stop the enclosing directive lookup at a less indented line

### DIFF
--- a/src/Traits/DirectiveTrait.php
+++ b/src/Traits/DirectiveTrait.php
@@ -143,6 +143,10 @@ trait DirectiveTrait
 
                 return false;
             }
+
+            if ($lineIndention < $currentIndention) {
+                $currentIndention = $lineIndention;
+            }
         }
 
         return false;

--- a/tests/Rule/EnsureAttributeBetweenBackticksInContentTest.php
+++ b/tests/Rule/EnsureAttributeBetweenBackticksInContentTest.php
@@ -65,6 +65,28 @@ final class EnsureAttributeBetweenBackticksInContentTest extends UnitTestCase
             new RstSample('use #[MapEntity] attributes'),
         ];
 
+        yield 'Has violation in a list item following a code-block' => [
+            Violation::from(
+                'Please ensure to use backticks "   then use #[MapEntity] attributes"',
+                'filename',
+                11,
+                'then use #[MapEntity] attributes',
+            ),
+            new RstSample([
+                '.. code-block:: diff',
+                '',
+                '    - "symfony/symfony": "*"',
+                '',
+                '#. Install Flex:',
+                '',
+                '   .. code-block:: terminal',
+                '',
+                '       $ composer require symfony/flex',
+                '',
+                '   then use #[MapEntity] attributes',
+            ], 10),
+        ];
+
         yield 'Has no violation' => [
             NullViolation::create(),
             new RstSample('use ``#[MapEntity]`` attributes'),

--- a/tests/Traits/DirectiveTraitTest.php
+++ b/tests/Traits/DirectiveTraitTest.php
@@ -297,6 +297,67 @@ RST;
             [RstParser::CODE_BLOCK_JAVASCRIPT],
         ];
 
+        $in_nested_yaml = <<<'RST'
+.. code-block:: yaml
+
+    framework:
+        messenger:
+            transports: ~
+RST;
+
+        yield [
+            true,
+            new RstSample($in_nested_yaml, 4),
+            RstParser::DIRECTIVE_CODE_BLOCK,
+        ];
+
+        $list_item_with_code_block = <<<'RST'
+.. code-block:: text
+
+    I am some output
+
+#. Install Flex:
+
+   .. code-block:: terminal
+
+       $ composer require symfony/flex
+
+   I am just a cool text!
+RST;
+
+        yield [
+            true,
+            new RstSample($list_item_with_code_block, 8),
+            RstParser::DIRECTIVE_CODE_BLOCK,
+        ];
+
+        yield [
+            false,
+            new RstSample($list_item_with_code_block, 10),
+            RstParser::DIRECTIVE_CODE_BLOCK,
+        ];
+
+        $definition_with_code_block = <<<'RST'
+.. code-block:: text
+
+    I am some output
+
+``consumer``
+    Typically set via an environment variable:
+
+    .. code-block:: yaml
+
+        consumer: '%env(MESSENGER_CONSUMER_NAME)%'
+
+    I am just a cool text!
+RST;
+
+        yield [
+            false,
+            new RstSample($definition_with_code_block, 11),
+            RstParser::DIRECTIVE_CODE_BLOCK,
+        ];
+
         yield [
             false,
             new RstSample(<<<'RST'


### PR DESCRIPTION
Fixes #2391.

`in()` only stopped at a less indented directive, so it climbed past the list item or definition term holding a nested code block, up to any earlier code block of the file. It now lowers the reference indentation whenever it meets a less indented line that is not a directive: a directive found further up is then the enclosing one only if every line in between is indented deeper than it. Content less indented than the checked line but still inside the block (an upper YAML key, for instance) still leads back to its directive.

### Tests

Four `in()` cases: two guards that stay `true` (nested YAML, a code block inside a list item), and the two shapes that returned `true` before, a list item and a definition list. Plus a case in `EnsureAttributeBetweenBackticksInContentTest` with an earlier diff block, since that rule only skips diff blocks today. The last three fail without the fix.

### Verification

The DOCtor-RST output of the symfony-docs 6.4, 7.4, 8.0, 8.1 and 8.2 branches is unchanged. With #2390 on top, an attribute added after each of their code blocks (about 3,500 per branch) is always reported, while 5 to 8 per branch were missed without this fix. The 2094 tests pass, PHPStan and PHP-CS-Fixer are clean.

#2390 depends on this one, since skipping every code block in `ensure_attribute_between_backticks_in_content` would extend this blind spot to all of them.
